### PR TITLE
Fix localization of the FirebaseAccountError

### DIFF
--- a/Sources/SpeziFirebaseAccount/FirebaseAccountError.swift
+++ b/Sources/SpeziFirebaseAccount/FirebaseAccountError.swift
@@ -18,7 +18,7 @@ enum FirebaseAccountError: LocalizedError {
     case unknown(AuthErrorCode.Code)
     
     
-    var errorDescription: String? {
+    private var errorDescriptionValue: String.LocalizationValue {
         switch self {
         case .invalidEmail:
             return "FIREBASE_ACCOUNT_ERROR_INVALID_EMAIL"
@@ -32,12 +32,16 @@ enum FirebaseAccountError: LocalizedError {
             return "FIREBASE_ACCOUNT_UNKNOWN"
         }
     }
+
+    private var errorDescription: String {
+        .init(localized: errorDescriptionValue, bundle: .module)
+    }
     
-    var failureReason: String? {
+    var failureReason: String {
         errorDescription
     }
     
-    var recoverySuggestion: String? {
+    private var recoverySuggestionValue: String.LocalizationValue {
         switch self {
         case .invalidEmail:
             return "FIREBASE_ACCOUNT_ERROR_INVALID_EMAIL_SUGGESTION"
@@ -51,7 +55,11 @@ enum FirebaseAccountError: LocalizedError {
             return "FIREBASE_ACCOUNT_UNKNOWN_SUGGESTION"
         }
     }
-    
+
+    var recoverySuggestion: String? {
+        .init(localized: recoverySuggestionValue, bundle: .module)
+    }
+
     
     init(authErrorCode: AuthErrorCode) {
         switch authErrorCode.code {

--- a/Sources/SpeziFirebaseAccount/FirebaseAccountError.swift
+++ b/Sources/SpeziFirebaseAccount/FirebaseAccountError.swift
@@ -33,11 +33,11 @@ enum FirebaseAccountError: LocalizedError {
         }
     }
 
-    private var errorDescription: String {
+    var errorDescription: String? {
         .init(localized: errorDescriptionValue, bundle: .module)
     }
     
-    var failureReason: String {
+    var failureReason: String? {
         errorDescription
     }
     


### PR DESCRIPTION
# Fix localization of the FirebaseAccountError

## :recycle: Current situation & Problem
Currently, the `FirebaseAccountError` doesn't provide the translated error descriptions but the `LocalizationValue`s. Therefore, the user won't get properly translated error messages.

## :bulb: Proposed solution
This PR fixes the issue by properly instantiation the localized strings.

## :gear: Release Notes 
* Fixed an issue where `FirebaseAccountError` localization weren't properly displayed.

## :heavy_plus_sign: Additional Information

CC @PSchmiedmayer (as I can't currently assign reviewers)

### Related PRs
--

### Testing
I'm not sure if FirebaseAccountError localizations were tested previously. So I currently didn't add additional UI tests as it seems like a major change to the UI test suite. I hope this is okay for this small change?

### Reviewer Nudging
Only small changes.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
