### PR TITLE
Upgrade tests to updated SpeziAccount

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.7.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", branch: "feature/signup-sheet-no-navigationstacks"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", .upToNextMinor(from: "0.5.1")),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.4.2")),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.13.0")
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.7.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", .upToNextMinor(from: "0.5.0")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", branch: "feature/signup-sheet-no-navigationstacks"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.4.2")),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.13.0")
     ],

--- a/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
@@ -19,7 +19,7 @@ final class FirebaseAccountTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         
-        // TODO try disablePasswordAutofill()
+        try disablePasswordAutofill()
 
         try await FirebaseClient.deleteAllAccounts()
         try await Task.sleep(for: .seconds(0.5))

--- a/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
@@ -19,7 +19,7 @@ final class FirebaseAccountTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         
-        try disablePasswordAutofill()
+        // TODO try disablePasswordAutofill()
 
         try await FirebaseClient.deleteAllAccounts()
         try await Task.sleep(for: .seconds(0.5))
@@ -392,10 +392,10 @@ extension XCUIApplication {
         XCTAssertTrue(staticTexts["Please fill out the details below to create a new account."].waitForExistence(timeout: 6.0))
         sleep(2)
 
-        try textFields["E-Mail Address"].enter(value: username)
+        try collectionViews.textFields["E-Mail Address"].enter(value: username)
         extendedDismissKeyboard()
         
-        try secureTextFields["Password"].enter(value: password)
+        try collectionViews.secureTextFields["Password"].enter(value: password)
         extendedDismissKeyboard()
         
         swipeUp()

--- a/Tests/UITests/TestAppUITests/FirebaseClient.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseClient.swift
@@ -51,7 +51,7 @@ struct FirestoreAccount: Decodable, Equatable {
 
 
 enum FirebaseClient {
-    private static let projectId = "spezifirebaseuitests"
+    private static let projectId = "nams-e43ed"
 
     // curl -H "Authorization: Bearer owner" -X DELETE http://localhost:9099/emulator/v1/projects/spezifirebaseuitests/accounts
     static func deleteAllAccounts() async throws {

--- a/Tests/UITests/TestAppUITests/FirebaseClient.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseClient.swift
@@ -51,7 +51,7 @@ struct FirestoreAccount: Decodable, Equatable {
 
 
 enum FirebaseClient {
-    private static let projectId = "nams-e43ed"
+    private static let projectId = "spezifirebaseuitests"
 
     // curl -H "Authorization: Bearer owner" -X DELETE http://localhost:9099/emulator/v1/projects/spezifirebaseuitests/accounts
     static func deleteAllAccounts() async throws {

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -569,8 +569,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziAccount.git";
 			requirement = {
-				branch = "feature/signup-sheet-no-navigationstacks";
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.5.1;
 			};
 		};
 		2F2E8EFD29E7369B00D439B7 /* XCRemoteSwiftPackageReference "SpeziViews" */ = {

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -569,8 +569,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziAccount.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.5.0;
+				branch = "feature/signup-sheet-no-navigationstacks";
+				kind = branch;
 			};
 		};
 		2F2E8EFD29E7369B00D439B7 /* XCRemoteSwiftPackageReference "SpeziViews" */ = {

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount.git",
       "state" : {
-        "branch" : "feature/signup-sheet-no-navigationstacks",
-        "revision" : "7076054cfa3ae69e2318c1667f615f1840db41f6"
+        "revision" : "1685d1c01a94f61ca6039df6cd22a94632ccab6d",
+        "version" : "0.5.1"
       }
     },
     {

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount.git",
       "state" : {
-        "revision" : "040aec4d6cf60c2a0f566dbef6f357dc74847507",
-        "version" : "0.5.0"
+        "branch" : "feature/signup-sheet-no-navigationstacks",
+        "revision" : "7076054cfa3ae69e2318c1667f615f1840db41f6"
       }
     },
     {


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Upgrade tests to updated SpeziAccount

## :recycle: Current situation & Problem
With https://github.com/StanfordSpezi/SpeziAccount/pull/23, SpeziAccount was updated to no longer automatically place itself into `NavigationStack`s and changed how the `SignupForm` is presented.
This PR fixes compatibility in tests.


## :gear: Release Notes 
* Fixe UITests compatibility with latest SpeziAccount release.


## :books: Documentation
Not affected.


## :white_check_mark: Testing
Tests were adjusted.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
