### PR TITLE
Adding support for Sign In with Apple

### DIFF
--- a/Sources/SpeziFirebaseAccount/FirebaseAccountConfiguration.swift
+++ b/Sources/SpeziFirebaseAccount/FirebaseAccountConfiguration.swift
@@ -58,6 +58,9 @@ public final class FirebaseAccountConfiguration: Component {
         if authenticationMethods.contains(.emailAndPassword) {
             self.accountServices.append(FirebaseEmailPasswordAccountService())
         }
+        if authenticationMethods.contains(.signInWithApple) {
+            self.accountServices.append(FirebaseIdentityProviderAccountService()) // TODO pass apple in here?
+        }
     }
     
     public func configure() {

--- a/Sources/SpeziFirebaseAccount/FirebaseAuthAuthenticationMethods.swift
+++ b/Sources/SpeziFirebaseAccount/FirebaseAuthAuthenticationMethods.swift
@@ -9,11 +9,20 @@
 
 /// Definition of the authentication methods supported by the FirebaseAccount module.
 public struct FirebaseAuthAuthenticationMethods: OptionSet {
+    // TODO document necessary steps:
+    //  email and password: enable in firebase
+    //  apple: Xcode project setup (add capabilities) => signing capabilities (account and stuff!)
+    //    - setup firebase (add sign in with apple)
+
     /// E-Mail and password-based authentication.
     public static let emailAndPassword = FirebaseAuthAuthenticationMethods(rawValue: 1 << 0)
-    
+    /// Sign In With Apple Identity Provider.
+    public static let signInWithApple = FirebaseAuthAuthenticationMethods(rawValue: 1 << 1)
+
+
     /// All authentication methods.
-    public static let all: FirebaseAuthAuthenticationMethods = [.emailAndPassword]
+    public static let all: FirebaseAuthAuthenticationMethods = [.emailAndPassword, .signInWithApple]
+    // TODO all doesn't make sense + we need a way to inejct from the outside (e.g. GoogleSignIn!)
     
     
     public let rawValue: Int

--- a/Sources/SpeziFirebaseAccount/FirebaseIdentityProviderAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/FirebaseIdentityProviderAccountService.swift
@@ -1,0 +1,205 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import AuthenticationServices
+import CryptoKit
+import FirebaseAuth
+import OSLog
+import SpeziAccount
+import SwiftUI
+
+
+struct FirebaseIdentityProviderViewStyle: IdentityProviderViewStyle {
+    let service: FirebaseIdentityProviderAccountService
+
+
+    init(service: FirebaseIdentityProviderAccountService) {
+        self.service = service
+    }
+
+
+    func makeSignInButton() -> some View {
+        FirebaseSignInWithAppleButton(service: service)
+    }
+}
+
+
+actor FirebaseIdentityProviderAccountService: IdentityProvider {
+    static let logger = Logger(subsystem: "edu.stanford.spezi.firebase", category: "IdentityProvider")
+
+    private static let supportedKeys = AccountKeyCollection {
+        \.userId
+        \.password // TODO remove this once we figure out how to support Account Service directed requirement level!
+        \.name
+    }
+
+    nonisolated var viewStyle: FirebaseIdentityProviderViewStyle {
+        FirebaseIdentityProviderViewStyle(service: self)
+    }
+
+    let configuration: AccountServiceConfiguration
+
+    @MainActor @AccountReference private var account: Account // property wrappers cannot be nonisolated, so we isolate it to main actor
+    @MainActor private var lastNonce: String?
+
+
+    init() { // TODO provider enum instantiation?
+        self.configuration = AccountServiceConfiguration(
+            name: "Identity Provider", // TODO source name from type
+            supportedKeys: .exactly(Self.supportedKeys) // TODO SpeziAccount support to automatically collect more!
+        ) {
+            RequiredAccountKeys {
+                \.userId // TODO not password right, anything else, does that make sense?
+            }
+            UserIdConfiguration(type: .emailAddress, keyboardType: .emailAddress)
+
+            // TODO field validation rules doesn't make sense right?
+        }
+    }
+
+    func signUp(signupDetails: SignupDetails) async throws {
+        // TODO actually check what we plug in! is that used?
+    }
+
+    func updateAccountDetails(_ modifications: AccountModifications) async throws {
+        // TODO reuse stuff?
+    }
+
+    func logout() async throws {
+        // TODO reuse everything!
+    }
+
+    func delete() async throws {
+        // TODO reuse everything?
+
+        // TODO token revocation!!! https://firebase.google.com/docs/auth/ios/apple
+    }
+
+    @MainActor
+    func onAppleSignInRequest(request: ASAuthorizationAppleIDRequest) {
+        let nonce = Self.randomNonceString(length: 32)
+        // we configured userId as `required` in the account service
+        var requestedScopes: [ASAuthorization.Scope] = [.email]
+
+        let nameRequirement = account.configuration[PersonNameKey.self]?.requirement
+        if nameRequirement == .required || nameRequirement == .collected {
+            requestedScopes.append(.fullName)
+        }
+
+        request.nonce = Self.sha256(nonce)
+        request.requestedScopes = requestedScopes
+
+        self.lastNonce = nonce // save the nonce for later use to be passed to FirebaseAuth
+    }
+
+    @MainActor
+    func onAppleSignInCompletion(result: Result<ASAuthorization, Error>) throws {
+        switch result {
+        case let .success(authorization):
+            guard let appleIdCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+                Self.logger.error("Unable to obtain credential as ASAuthorizationAppleIDCredential")
+                throw FirebaseAccountError.setupError // TODO it's not just account creation!
+            }
+
+            guard let lastNonce else {
+                Self.logger.error("onAppleSignInCompletion was received though no login request was found.")
+                throw FirebaseAccountError.setupError
+            }
+
+            guard let identityToken = appleIdCredential.identityToken else {
+                Self.logger.error("Unable to fetch identityToken from ASAuthorizationAppleIDCredential.")
+                throw FirebaseAccountError.setupError
+            }
+
+            guard let identityTokenString = String(data: identityToken, encoding: .utf8) else {
+                Self.logger.error("Unable to serialize identityToken to utf8 string.")
+                throw FirebaseAccountError.setupError
+            }
+
+
+            Self.logger.info("onAppleSignInCompletion creating firebase apple credential from authorization credential")
+
+            // the appleIdCredential.fullName is only provided on first contact. After that Apple won't supply that anymore!
+            // TODO we are only getting the name on first call, see https://firebase.google.com/docs/auth/ios/apple
+            let credential = OAuthProvider.appleCredential(
+                withIDToken: identityTokenString,
+                rawNonce: lastNonce,
+                fullName: appleIdCredential.fullName
+            )
+            // TODO would be pass this now to our own signup method, or how does that ideally work?
+            // TODO we also might need to source additional information!
+            //  => API support to calculate diffing what is required still!
+
+            print(identityTokenString) // TODO remove!!!
+            print(credential)
+
+            Task { // TODO create a task earlier to report error back as well!
+                do {
+                    try await Auth.auth().signIn(with: credential)
+
+                    // TODO we are now signed in and need to query additional data!
+                } catch {
+                    print("ERROR: \(error)") // TODO forward at some point?
+                }
+            }
+        case let .failure(error):
+            guard let authorizationError = error as? ASAuthorizationError else {
+                Self.logger.error("onAppleSignInCompletion received unknown error: \(error)")
+                // TODO forward localized description
+                break
+            }
+
+            Self.logger.error("Received ASAuthorizationError error: \(authorizationError)")
+
+            switch ASAuthorizationError.Code(rawValue: authorizationError.errorCode) {
+            case .unknown, .canceled:
+                // unknown is thrown if e.g. user is not logged in at all. Apple will show a pop up then!
+                // cancelled is user interaction, no need to show anything
+                break
+            case .invalidResponse:
+                break // TODO The authorization request received an invalid response.
+            case .notHandled:
+                break // TODO The authorization request wasn’t handled.
+            case .failed:
+                break // TODO The authorization attempt failed.
+            case .notInteractive:
+                break // TODO The authorization request isn’t interactive.
+            default:
+                break
+            }
+
+            self.lastNonce = nil
+
+            // TODO render some error back in the UI! (just throw?)
+        }
+    }
+
+
+    // TODO move both somewhere else!
+    private static func randomNonceString(length: Int) -> String {
+        precondition(length > 0, "Nonce length must be non-zero")
+        let nonceCharacters = (0 ..< length).map { _ in
+            // ASCII alphabet goes from 32 (space) to 126 (~)
+            let num = Int.random(in: 32...126)
+            guard let scalar = UnicodeScalar(num) else {
+                preconditionFailure("Failed to generate ASCII character for nonce!")
+            }
+            return Character(scalar)
+        }
+
+        return String(nonceCharacters)
+    }
+
+    private static func sha256(_ input: String) -> String {
+        SHA256.hash(data: Data(input.utf8))
+            .compactMap { byte in
+                String(format: "%02x", byte)
+            }
+            .joined()
+    }
+}

--- a/Sources/SpeziFirebaseAccount/IdentityProvider/FirebaseSignInWithAppleButton.swift
+++ b/Sources/SpeziFirebaseAccount/IdentityProvider/FirebaseSignInWithAppleButton.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import AuthenticationServices
+import SwiftUI
+
+
+struct FirebaseSignInWithAppleButton: View {
+    private let accountService: FirebaseIdentityProviderAccountService
+
+    @Environment(\.colorScheme)
+    private var colorScheme
+
+    var body: some View {
+        // TODO do we need to control the label!
+        SignInWithAppleButton(onRequest: { request in
+            accountService.onAppleSignInRequest(request: request)
+        }, onCompletion: { result in
+            // TODO display error!
+            try? accountService.onAppleSignInCompletion(result: result)
+        })
+            .frame(height: 55)
+            .signInWithAppleButtonStyle(colorScheme == .light ? .black : .white)
+    }
+
+    init(service: FirebaseIdentityProviderAccountService) {
+        self.accountService = service
+    }
+}

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -19,7 +19,7 @@ class TestAppDelegate: SpeziAppDelegate {
         Configuration {
             AccountConfiguration(configuration: [
                 .requires(\.userId),
-                .requires(\.password),
+                .requires(\.password), // TODO how do we solve this, not a necessity right?
                 .collects(\.name)
             ])
             Firestore(settings: .emulator)

--- a/Tests/UITests/TestApp/TestApp.entitlements
+++ b/Tests/UITests/TestApp/TestApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		97359F652ADB286D0080CB11 /* StorageMetadata+Sendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageMetadata+Sendable.swift"; sourceTree = "<group>"; };
 		978E198D2ADB40A300732324 /* FirebaseStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseStorageTests.swift; sourceTree = "<group>"; };
 		A95D60CF2AA35E2200EB5968 /* FirebaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseClient.swift; sourceTree = "<group>"; };
+		A9B628E82ADF559E00F2BBD8 /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +121,7 @@
 		2F6D139428F5F384007C25D6 /* TestApp */ = {
 			isa = PBXGroup;
 			children = (
+				A9B628E82ADF559E00F2BBD8 /* TestApp.entitlements */,
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
 				2F148BFE298BB14100031B7F /* FirebaseAccountTests */,
 				2FE62C3B2966071400FCBE7F /* FirestoreDataStorageTests */,
@@ -448,6 +450,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -483,6 +486,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "8a8ec57a272e0d31480fb0893dda0cf4f769b57e",
-        "version" : "10.15.0"
+        "revision" : "837d4af6ead57cec1fc38007892500d3139c7556",
+        "version" : "10.16.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "03b9beee1a61f62d32c521e172e192a1663a5e8b",
-        "version" : "10.13.0"
+        "revision" : "56f681586ff006a7982b53dc94082eea31971acf",
+        "version" : "10.16.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "f1b366129d1125be7db83247e003fc333104b569",
-        "version" : "1.50.2"
+        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
+        "version" : "1.49.1"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi",
       "state" : {
-        "revision" : "7462510badaa156c1e25efd7eabbf5b85ecb0098",
-        "version" : "0.7.2"
+        "revision" : "e75ea4d241b6eb611ca4c1c25926097cf324ce37",
+        "version" : "0.7.3"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount.git",
       "state" : {
-        "revision" : "1685d1c01a94f61ca6039df6cd22a94632ccab6d",
-        "version" : "0.5.1"
+        "revision" : "1eca29373a5c27e7dfe7871be77be306ca626989",
+        "version" : "0.5.3"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziStorage",
       "state" : {
-        "revision" : "739ee1eadc5f9b1b5d2e8752ba077243d42fa79f",
-        "version" : "0.4.2"
+        "revision" : "58f79a21291da6d2d2193275486fa3c69b4f31fa",
+        "version" : "0.4.3"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziViews.git",
       "state" : {
-        "revision" : "626914fa7554aa2b994257541c0794eb930520ba",
-        "version" : "0.5.0"
+        "revision" : "4b7cc423fd823123d354ec1d541ca7d2e0a9d6e3",
+        "version" : "0.5.1"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
+        "version" : "1.0.5"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "cf62cdaea48b77f1a631e5cb3aeda6047c2cba1d",
-        "version" : "1.23.0"
+        "revision" : "3c54ab05249f59f2c6641dd2920b8358ea9ed127",
+        "version" : "1.24.0"
       }
     },
     {


### PR DESCRIPTION
# Adding support for Sign In with Apple

## :recycle: Current situation & Problem
Currently, we only support email- and password-based authentication using Firebase. This PR makes the first step to add single sign on providers by adding support for Sign in with Apple.

_The PR is currently a draft and will certainly requires some changes on SpeziAccount._

## :gear: Release Notes 
* Add support for Sign In with Apple


## :books: Documentation
_TBA_


## :white_check_mark: Testing
_TBA_


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
