### PR TITLE
Fixes and improvements for Sign in with Apple

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.7.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", branch: "feature/standard-backed-visibility"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", .upToNextMinor(from: "0.6.1")),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.4.2")),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.13.0")
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.7.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", .upToNextMinor(from: "0.6.0")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", branch: "feature/standard-backed-visibility"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.4.2")),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.13.0")
     ],

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseEmailPasswordAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseEmailPasswordAccountService.swift
@@ -123,7 +123,12 @@ actor FirebaseEmailPasswordAccountService: UserIdPasswordAccountService, Firebas
         }
     }
 
-    func reauthenticateUser(userId: String, user: User) async {
+    func reauthenticateUser(user: User) async {
+        guard let userId = user.email else {
+            return
+        }
+
+        // with a future version of SpeziAccount we want to get rid of this workaround and request the password from the user on the fly.
         guard let password = context.retrieveCredential(userId: userId, server: StorageKeys.emailPasswordCredentials) else {
             return // nothing we can do
         }

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
@@ -235,7 +235,10 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
 
     private func performRequest(_ request: ASAuthorizationAppleIDRequest) async throws -> ASAuthorizationResult? {
         guard let authorizationController else {
-            Self.logger.error("Failed to perform AppleID request. We are missing access to the AuthorizationController. Did you set up the .firebaseAccount() modifier?")
+            Self.logger.error("""
+                              Failed to perform AppleID request. We are missing access to the AuthorizationController. \
+                              Did you set up the .firebaseAccount() modifier?
+                              """)
             throw FirebaseAccountError.setupError
         }
 

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
@@ -69,6 +69,7 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
     }
 
     func inject(authorizationController: AuthorizationController) {
+        Self.logger.debug("Received authorization controller injection ...")
         self.authorizationController = authorizationController
     }
 

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
@@ -77,7 +77,7 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
         // nothing we are doing here
     }
 
-    func reauthenticateUser(userId: String, user: User) async throws {
+    func reauthenticateUser(user: User) async throws {
         guard let appleIdCredential = try await requestAppleSignInCredential() else {
             return // user canceled
         }
@@ -122,6 +122,10 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
                 Self.logger.error("Unable to serialize authorizationCode to utf8 string.")
                 throw FirebaseAccountError.setupError
             }
+
+            Self.logger.debug("Re-Authenticating Apple Credential before deleting user account ...")
+            let authCredential = try await oAuthCredential(from: credential)
+            try await currentUser.reauthenticate(with: authCredential)
 
             do {
                 Self.logger.debug("Revoking Apple Id Token ...")

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
@@ -123,6 +123,7 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
             }
 
             do {
+                Self.logger.debug("Revoking Apple Id Token ...")
                 try await Auth.auth().revokeToken(withAuthorizationCode: authorizationCodeString)
             } catch let error as NSError {
                 #if targetEnvironment(simulator)
@@ -139,7 +140,6 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
                 throw error
             }
 
-            print("Deleting")
             try await currentUser.delete()
             Self.logger.debug("delete() for user.")
         }
@@ -214,6 +214,7 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
 
 
     private func requestAppleSignInCredential() async throws -> ASAuthorizationAppleIDCredential? {
+        Self.logger.debug("Requesting on the fly Sign in with Apple")
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
 
@@ -234,6 +235,7 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
 
     private func performRequest(_ request: ASAuthorizationAppleIDRequest) async throws -> ASAuthorizationResult? {
         guard let authorizationController else {
+            Self.logger.error("Failed to perform AppleID request. We are missing access to the AuthorizationController. Did you set up the .firebaseAccount() modifier?")
             throw FirebaseAccountError.setupError
         }
 

--- a/Sources/SpeziFirebaseAccount/Utils/CryptoUtils.swift
+++ b/Sources/SpeziFirebaseAccount/Utils/CryptoUtils.swift
@@ -14,8 +14,8 @@ enum CryptoUtils {
     static func randomNonceString(length: Int) -> String {
         precondition(length > 0, "Nonce length must be non-zero")
         let nonceCharacters = (0 ..< length).map { _ in
-            // ASCII alphabet goes from 32 (space) to 126 (~)
-            let num = Int.random(in: 32...126) // .random(in:) is secure, see https://stackoverflow.com/a/76722233
+            // ASCII alphabet goes from 32 (space) to 126 (~); Firebase seems to have problems with some special characters!
+            let num = Int.random(in: 48...122) // .random(in:) is secure, see https://stackoverflow.com/a/76722233
             guard let scalar = UnicodeScalar(num) else {
                 preconditionFailure("Failed to generate ASCII character for nonce!")
             }

--- a/Sources/SpeziFirebaseAccount/Utils/FirebaseContext.swift
+++ b/Sources/SpeziFirebaseAccount/Utils/FirebaseContext.swift
@@ -110,8 +110,10 @@ actor FirebaseContext {
 
             try await dispatchQueuedChanges(result: result)
         } catch let error as NSError {
+            Self.logger.error("Received NSError on firebase dispatch: \(error)")
             throw FirebaseAccountError(authErrorCode: AuthErrorCode(_nsError: error))
         } catch {
+            Self.logger.error("Received error on firebase dispatch: \(error)")
             throw FirebaseAccountError.unknown(.internalError)
         }
     }

--- a/Sources/SpeziFirebaseAccount/Utils/FirebaseContext.swift
+++ b/Sources/SpeziFirebaseAccount/Utils/FirebaseContext.swift
@@ -250,6 +250,7 @@ actor FirebaseContext {
         case let .user(user):
             let isNewUser = update.authResult?.additionalUserInfo?.isNewUser ?? false
             guard let service = update.service else {
+                Self.logger.error("Failed to dispatch user update due to missing account service!")
                 throw FirebaseAccountError.setupError
             }
 
@@ -261,6 +262,7 @@ actor FirebaseContext {
 
     func notifyUserSignIn(user: User, for service: any FirebaseAccountService, isNewUser: Bool = false) async throws {
         guard let email = user.email else {
+            Self.logger.error("Failed to associate firebase account due to missing email address.")
             throw FirebaseAccountError.invalidEmail
         }
 

--- a/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
+++ b/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
@@ -34,7 +34,7 @@ struct FirebaseAccountModifier: ViewModifier {
                 .task {
                     Self.logger.debug("Looking at \(account.registeredAccountServices.count) account services to inject authorization controller ...")
                     for service in account.registeredAccountServices {
-                        guard let firebaseService = service as? any FirebaseAccountService else {
+                        guard let firebaseService = service.castFirebaseAccountService() else {
                             continue
                         }
 
@@ -45,6 +45,23 @@ struct FirebaseAccountModifier: ViewModifier {
         } else {
             content
         }
+    }
+}
+
+
+extension AccountService {
+    fileprivate func castFirebaseAccountService() -> (any FirebaseAccountService)? {
+        if let firebaseService = self as? any FirebaseAccountService {
+            return firebaseService
+        }
+
+        let mirror = Mirror(reflecting: self) // checking if its a StandardBacked account service
+        if let accountService = mirror.children["accountService"],
+           let firebaseService = accountService as? any FirebaseAccountService {
+            return firebaseService
+        }
+
+        return nil
     }
 }
 

--- a/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
+++ b/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
@@ -56,7 +56,7 @@ extension AccountService {
         }
 
         let mirror = Mirror(reflecting: self) // checking if its a StandardBacked account service
-        if let accountService = mirror.children["accountService"],
+        if let accountService = mirror.children.first(where: { $0.label == "accountService" }),
            let firebaseService = accountService as? any FirebaseAccountService {
             return firebaseService
         }

--- a/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
+++ b/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
@@ -53,15 +53,12 @@ extension AccountService {
     fileprivate func castFirebaseAccountService() -> (any FirebaseAccountService)? {
         if let firebaseService = self as? any FirebaseAccountService {
             return firebaseService
-        }
-
-        let mirror = Mirror(reflecting: self) // checking if its a StandardBacked account service
-        if let accountService = mirror.children.first(where: { $0.label == "accountService" }),
-           let firebaseService = accountService as? any FirebaseAccountService {
+        } else if let standardBacked = self as? any _StandardBacked,
+                  let firebaseService = standardBacked.underlyingService as? any FirebaseAccountService {
             return firebaseService
+        } else {
+            return nil
         }
-
-        return nil
     }
 }
 

--- a/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
+++ b/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
@@ -7,11 +7,14 @@
 //
 
 import AuthenticationServices
+import OSLog
 import SpeziAccount
 import SwiftUI
 
 
 struct FirebaseAccountModifier: ViewModifier {
+    static let logger = Logger(subsystem: "edu.stanford.spezi.firebase", category: "FirebaseAccount")
+
     private let enable: Bool
 
     @EnvironmentObject private var account: Account
@@ -29,11 +32,13 @@ struct FirebaseAccountModifier: ViewModifier {
         if enable {
             content
                 .task {
+                    Self.logger.debug("Looking at \(account.registeredAccountServices.count) account services to inject authorization controller ...")
                     for service in account.registeredAccountServices {
                         guard let firebaseService = service as? any FirebaseAccountService else {
                             continue
                         }
 
+                        Self.logger.debug("Injecting authorization controller into \(type(of: firebaseService))")
                         await firebaseService.inject(authorizationController: authorizationController)
                     }
                 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -599,7 +599,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziAccount.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.6.0;
+				minimumVersion = 0.6.1;
 			};
 		};
 		2F2E8EFD29E7369B00D439B7 /* XCRemoteSwiftPackageReference "SpeziViews" */ = {

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount.git",
       "state" : {
-        "revision" : "2f88e04a66bb3f1444763f7e3c103353b9be6f77",
-        "version" : "0.6.0"
+        "revision" : "81a215080070d419140cc55bd478f2177176623c",
+        "version" : "0.6.1"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "3c54ab05249f59f2c6641dd2920b8358ea9ed127",
-        "version" : "1.24.0"
+        "revision" : "7dade5ea5ab0d05a2dd28f9cc6a6ea0d50588857",
+        "version" : "1.25.0"
       }
     },
     {


### PR DESCRIPTION
# Fixes and improvements for Sign in with Apple

## :recycle: Current situation & Problem
We recently tried to deploy Sign in with Apple to a live system and found several issues with the current implementation:
* Nonce generation found to be incompatible with Firebase (they are seemingly unable to handle some special characters)
* The `.firebaseAccount(_:)` modifier had issues injecting the `AuthorizationController` if there was a standard (e.g. notify or storage standard) injected into SpeziAccount
* Firebase account deletion requires a recent login.

This PR requires https://github.com/StanfordSpezi/SpeziAccount/pull/31 to be merged.
## :gear: Release Notes 
Fixes and improvements for Sign in with Apple.


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
