### PR TITLE
Add user-linking logic for signing up

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.0.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.0.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.0.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", branch: "fix/modifier-edit-view"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", from: "1.2.2"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.13.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.0.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.0.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.0.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", from: "1.0.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", branch: "fix/modifier-edit-view"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.13.0")
     ],
     targets: [

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseAccountError.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseAccountError.swift
@@ -20,6 +20,8 @@ enum FirebaseAccountError: LocalizedError {
     case notSignedIn
     case requireRecentLogin
     case appleFailed
+    case linkFailedDuplicate
+    case linkFailedAlreadyInUse
     case unknown(AuthErrorCode.Code)
     
     
@@ -43,6 +45,10 @@ enum FirebaseAccountError: LocalizedError {
             return "FIREBASE_ACCOUNT_REQUIRE_RECENT_LOGIN_ERROR"
         case .appleFailed:
             return "FIREBASE_APPLE_FAILED"
+        case .linkFailedDuplicate:
+            return "FIREBASE_ACCOUNT_LINK_FAILED_DUPLICATE"
+        case .linkFailedAlreadyInUse:
+            return "FIREBASE_ACCOUNT_LINK_FAILED_ALREADY_IN_USE"
         case .unknown:
             return "FIREBASE_ACCOUNT_UNKNOWN"
         }
@@ -72,6 +78,10 @@ enum FirebaseAccountError: LocalizedError {
             return "FIREBASE_ACCOUNT_REQUIRE_RECENT_LOGIN_ERROR_SUGGESTION"
         case .appleFailed:
             return "FIREBASE_APPLE_FAILED_SUGGESTION"
+        case .linkFailedDuplicate:
+            return "FIREBASE_ACCOUNT_LINK_FAILED_DUPLICATE_SUGGESTION"
+        case .linkFailedAlreadyInUse:
+            return "FIREBASE_ACCOUNT_LINK_FAILED_ALREADY_IN_USE_SUGGESTION"
         case .unknown:
             return "FIREBASE_ACCOUNT_UNKNOWN_SUGGESTION"
         }
@@ -100,6 +110,10 @@ enum FirebaseAccountError: LocalizedError {
             self = .setupError
         case .requiresRecentLogin:
             self = .requireRecentLogin
+        case .providerAlreadyLinked:
+            self = .linkFailedDuplicate
+        case .credentialAlreadyInUse:
+            self = .linkFailedAlreadyInUse
         default:
             self = .unknown(authErrorCode.code)
         }

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseEmailPasswordAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseEmailPasswordAccountService.swift
@@ -87,6 +87,17 @@ actor FirebaseEmailPasswordAccountService: UserIdPasswordAccountService, Firebas
         }
 
         try await context.dispatchFirebaseAuthAction(on: self) {
+            if let currentUser = Auth.auth().currentUser,
+               currentUser.isAnonymous {
+                let credential = EmailAuthProvider.credential(withEmail: signupDetails.userId, password: password)
+                Self.logger.debug("Linking email-password credentials with current anonymous user account ...")
+                let result = try await currentUser.link(with: credential)
+
+                try await context.notifyUserSignIn(user: currentUser, for: self, isNewUser: true)
+
+                return
+            }
+
             let authResult = try await Auth.auth().createUser(withEmail: signupDetails.userId, password: password)
             Self.logger.debug("createUser(withEmail:password:) for user.")
 

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
@@ -82,6 +82,17 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
         }
 
         try await context.dispatchFirebaseAuthAction(on: self) {
+            if let currentUser = Auth.auth().currentUser,
+               let password = signupDetails.password {
+                // User is already signed in; prepare credentials for linking.
+                let credential = EmailAuthProvider.credential(withEmail: signupDetails.userId, password: password)
+                let authResult = try await currentUser.link(with: credential)
+                Self.logger.debug("Existing user linked with email and password credentials.")
+                
+                return authResult
+            }
+            
+            // Otherwise, no user is signed in; create a new user.
             let authResult = try await Auth.auth().signIn(with: credential)
             Self.logger.debug("signIn(with:) credential for user.")
 

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseIdentityProviderAccountService.swift
@@ -83,16 +83,15 @@ actor FirebaseIdentityProviderAccountService: IdentityProvider, FirebaseAccountS
 
         try await context.dispatchFirebaseAuthAction(on: self) {
             if let currentUser = Auth.auth().currentUser,
-               let password = signupDetails.password {
-                // User is already signed in; prepare credentials for linking.
-                let credential = EmailAuthProvider.credential(withEmail: signupDetails.userId, password: password)
-                let authResult = try await currentUser.link(with: credential)
-                Self.logger.debug("Existing user linked with email and password credentials.")
-                
-                return authResult
+               currentUser.isAnonymous {
+                Self.logger.debug("Linking oauth credentials with current anonymous user account ...")
+                let result = try await currentUser.link(with: credential)
+
+                try await context.notifyUserSignIn(user: currentUser, for: self, isNewUser: true)
+
+                return result
             }
-            
-            // Otherwise, no user is signed in; create a new user.
+
             let authResult = try await Auth.auth().signIn(with: credential)
             Self.logger.debug("signIn(with:) credential for user.")
 

--- a/Sources/SpeziFirebaseAccount/Models/FirebaseContext.swift
+++ b/Sources/SpeziFirebaseAccount/Models/FirebaseContext.swift
@@ -260,6 +260,13 @@ actor FirebaseContext {
         switch update.change {
         case let .user(user):
             let isNewUser = update.authResult?.additionalUserInfo?.isNewUser ?? false
+            if user.isAnonymous {
+                // We explicitly handle anonymous users on every signup and call our state change handler ourselves.
+                // But generally, we don't care about anonymous users.
+                // TODO: what if they login?
+                return
+            }
+
             guard let service = update.service else {
                 Self.logger.error("Failed to dispatch user update due to missing account service identifier on disk!")
                 do {

--- a/Sources/SpeziFirebaseAccount/Models/FirebaseContext.swift
+++ b/Sources/SpeziFirebaseAccount/Models/FirebaseContext.swift
@@ -263,7 +263,6 @@ actor FirebaseContext {
             if user.isAnonymous {
                 // We explicitly handle anonymous users on every signup and call our state change handler ourselves.
                 // But generally, we don't care about anonymous users.
-                // TODO: what if they login?
                 return
             }
 

--- a/Sources/SpeziFirebaseAccount/Resources/Localizable.xcstrings
+++ b/Sources/SpeziFirebaseAccount/Resources/Localizable.xcstrings
@@ -2,10 +2,24 @@
   "sourceLanguage" : "en",
   "strings" : {
     "Authentication Required" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication Required"
+          }
+        }
+      }
     },
     "Cancel" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
     },
     "E-Mail Verified" : {
       "localizations" : {
@@ -13,6 +27,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "E-Mail verifiziert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-Mail Verified"
           }
         }
       }
@@ -157,6 +177,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Please verify that your email and password are correct."
+          }
+        }
+      }
+    },
+    "FIREBASE_ACCOUNT_LINK_FAILED_ALREADY_IN_USE" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to link account"
+          }
+        }
+      }
+    },
+    "FIREBASE_ACCOUNT_LINK_FAILED_ALREADY_IN_USE_SUGGESTION" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The credentials are already used with a different account."
+          }
+        }
+      }
+    },
+    "FIREBASE_ACCOUNT_LINK_FAILED_DUPLICATE" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to link account"
+          }
+        }
+      }
+    },
+    "FIREBASE_ACCOUNT_LINK_FAILED_DUPLICATE_SUGGESTION" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This type of account provider is already linked to this account."
           }
         }
       }

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount",
       "state" : {
-        "revision" : "a7d289ef3be54de62b25dc92e8f7ff1a0f093906",
-        "version" : "1.2.1"
+        "branch" : "fix/modifier-edit-view",
+        "revision" : "743087fab554ff8489efe22a36184e1064376c67"
       }
     },
     {

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount",
       "state" : {
-        "branch" : "fix/modifier-edit-view",
-        "revision" : "743087fab554ff8489efe22a36184e1064376c67"
+        "revision" : "cb9441e5fe9ca31a17be2507d03817a080e63e9d",
+        "version" : "1.2.2"
       }
     },
     {


### PR DESCRIPTION
# Account Linking

## :recycle: Current situation & Problem
In the `FirebaseEmailPasswordAccountService` of our project, the `signUp` function solely handles the creation of new user accounts or signing in with OAuth credentials. This process did not account for users who are already signed in (possibly anonymously) and wish to link their accounts with email and password credentials. See [#54](https://github.com/StanfordBDHG/PediatricAppleWatchStudy/pull/54) for details.


## :gear: Release Notes 
- The `signUp` function in `FirebaseEmailPasswordAccountService` now supports linking new email and password credentials to already signed-in users (including anonymous accounts).
- If onboarding starts with an anonymous account, users can expect a seamless transition when upgrading from said anonymous account to a permanent one.
- Fixes an issue where the reauthentication alert doesn't work.


## :books: Documentation
The modification ensures that if a user is already signed in (anonymously or with OAuth credentials), their account can be upgraded with email and password credentials by linking these new credentials to their existing account. See [Firebase documentation](https://firebase.google.com/docs/auth/ios/anonymous-auth) for details.


## :white_check_mark: Testing
TBD.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
