### PR TITLE
Ensure name is updated after anonymous account linking

### DIFF
--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseAccountService.swift
@@ -113,10 +113,7 @@ extension FirebaseAccountService {
             }
 
             if let name = modifications.modifiedDetails.name {
-                Self.logger.debug("Creating change request for updated display name.")
-                let changeRequest = currentUser.createProfileChangeRequest()
-                changeRequest.displayName = name.formatted(.name(style: .long))
-                try await changeRequest.commitChanges()
+                try await updateDisplayName(of: currentUser, name)
             }
 
             // None of the above requests will trigger our state change listener, therefore, we just call it manually.
@@ -128,5 +125,12 @@ extension FirebaseAccountService {
             Self.logger.error("Received error on firebase dispatch: \(error)")
             throw FirebaseAccountError.unknown(.internalError)
         }
+    }
+
+    func updateDisplayName(of user: User, _ name: PersonNameComponents) async throws {
+        Self.logger.debug("Creating change request for updated display name.")
+        let changeRequest = user.createProfileChangeRequest()
+        changeRequest.displayName = name.formatted(.name(style: .long))
+        try await changeRequest.commitChanges()
     }
 }

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseEmailPasswordAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseEmailPasswordAccountService.swift
@@ -93,6 +93,10 @@ actor FirebaseEmailPasswordAccountService: UserIdPasswordAccountService, Firebas
                 Self.logger.debug("Linking email-password credentials with current anonymous user account ...")
                 let result = try await currentUser.link(with: credential)
 
+                if let displayName = signupDetails.name {
+                    try await updateDisplayName(of: currentUser, displayName)
+                }
+
                 try await context.notifyUserSignIn(user: currentUser, for: self, isNewUser: true)
 
                 return
@@ -105,10 +109,7 @@ actor FirebaseEmailPasswordAccountService: UserIdPasswordAccountService, Firebas
             try await authResult.user.sendEmailVerification()
 
             if let displayName = signupDetails.name {
-                Self.logger.debug("Creating change request for display name.")
-                let changeRequest = authResult.user.createProfileChangeRequest()
-                changeRequest.displayName = displayName.formatted(.name(style: .medium))
-                try await changeRequest.commitChanges()
+                try await updateDisplayName(of: authResult.user, displayName)
             }
         }
     }

--- a/Sources/SpeziFirebaseAccount/Account Services/FirebaseEmailPasswordAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/Account Services/FirebaseEmailPasswordAccountService.swift
@@ -94,10 +94,10 @@ actor FirebaseEmailPasswordAccountService: UserIdPasswordAccountService, Firebas
                 let result = try await currentUser.link(with: credential)
 
                 if let displayName = signupDetails.name {
-                    try await updateDisplayName(of: currentUser, displayName)
+                    try await updateDisplayName(of: result.user, displayName)
                 }
 
-                try await context.notifyUserSignIn(user: currentUser, for: self, isNewUser: true)
+                try await context.notifyUserSignIn(user: result.user, for: self)
 
                 return
             }

--- a/Tests/UITests/TestApp/FirebaseStorageTests/FirebaseStorageTestsView.swift
+++ b/Tests/UITests/TestApp/FirebaseStorageTests/FirebaseStorageTestsView.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import FirebaseStorage
+@preconcurrency import FirebaseStorage
 import PDFKit
 import SpeziViews
 import SwiftUI
@@ -35,7 +35,9 @@ struct FirebaseStorageTestsView: View {
                 let ref = Storage.storage().reference().child("test.txt")
                 let metadata = StorageMetadata()
                 metadata.contentType = "text/plain"
-                _ = try await ref.putDataAsync("Hello World!".data(using: .utf8) ?? .init(), metadata: metadata)
+                _ = try await ref.putDataAsync("Hello World!".data(using: .utf8) ?? .init(), metadata: metadata) { @Sendable _ in
+                    // silence warning
+                }
                 viewState = .idle
             } catch {
                 viewState = .error(AnyLocalizedError(error: error))

--- a/Tests/UITests/TestApp/FirestoreDataStorageTests/FirestoreDataStorageTests.swift
+++ b/Tests/UITests/TestApp/FirestoreDataStorageTests/FirestoreDataStorageTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import FirebaseFirestore
+@preconcurrency import FirebaseFirestore
 import Spezi
 import SpeziFirestore
 import SpeziViews

--- a/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
@@ -448,7 +448,7 @@ final class FirebaseAccountTests: XCTestCase { // swiftlint:disable:this type_bo
 
     func testSignupAccountLinking() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["--firebaseAccount"]
+        app.launchArguments = ["--account-storage"]
         app.launch()
 
         XCTAssert(app.buttons["FirebaseAccount"].waitForExistence(timeout: 10.0))
@@ -463,9 +463,11 @@ final class FirebaseAccountTests: XCTestCase { // swiftlint:disable:this type_bo
 
         XCTAssertTrue(app.staticTexts["User, Anonymous"].waitForExistence(timeout: 5.0))
 
-        try app.signup(username: "test@username2.edu", password: "TestPassword2", givenName: "Leland", familyName: "Stanford", closeSheet: false)
+        try app.signup(username: "test@username2.edu", password: "TestPassword2", givenName: "Leland", familyName: "Stanford", biography: "Bio")
 
-        XCTAssert(app.staticTexts["Leland Stanford"].waitForExistence(timeout: 7.0))
+        app.buttons["Account Overview"].tap()
+        XCTAssert(app.staticTexts["Leland Stanford"].waitForExistence(timeout: 2.0))
+        XCTAssert(app.staticTexts["Biography, Bio"].exists)
     }
 }
 
@@ -488,7 +490,7 @@ extension XCUIApplication {
         }
     }
 
-    func signup(username: String, password: String, givenName: String, familyName: String, biography: String? = nil, closeSheet: Bool = true) throws {
+    func signup(username: String, password: String, givenName: String, familyName: String, biography: String? = nil) throws {
         buttons["Account Setup"].tap()
         buttons["Signup"].tap()
 
@@ -513,10 +515,7 @@ extension XCUIApplication {
         collectionViews.buttons["Signup"].tap()
 
         sleep(3)
-
-        if closeSheet {
-            buttons["Close"].tap()
-        }
+        buttons["Close"].tap()
     }
 }
 // swiftlint:disable:this file_length

--- a/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
@@ -445,6 +445,28 @@ final class FirebaseAccountTests: XCTestCase { // swiftlint:disable:this type_bo
 
         app.tap() // that triggers the interruption monitor closure
     }
+
+    func testSignupAccountLinking() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--firebaseAccount"]
+        app.launch()
+
+        XCTAssert(app.buttons["FirebaseAccount"].waitForExistence(timeout: 10.0))
+        app.buttons["FirebaseAccount"].tap()
+
+        if app.buttons["Logout"].waitForExistence(timeout: 3.0) && app.buttons["Logout"].isHittable {
+            app.buttons["Logout"].tap()
+        }
+
+        XCTAssertTrue(app.buttons["Login Anonymously"].waitForExistence(timeout: 2.0))
+        app.buttons["Login Anonymously"].tap()
+
+        XCTAssertTrue(app.staticTexts["User, Anonymous"].waitForExistence(timeout: 5.0))
+
+        try app.signup(username: "test@username2.edu", password: "TestPassword2", givenName: "Leland", familyName: "Stanford", closeSheet: false)
+
+        XCTAssert(app.staticTexts["Leland Stanford"].waitForExistence(timeout: 7.0))
+    }
 }
 
 
@@ -466,7 +488,7 @@ extension XCUIApplication {
         }
     }
 
-    func signup(username: String, password: String, givenName: String, familyName: String, biography: String? = nil) throws {
+    func signup(username: String, password: String, givenName: String, familyName: String, biography: String? = nil, closeSheet: Bool = true) throws {
         buttons["Account Setup"].tap()
         buttons["Signup"].tap()
 
@@ -491,6 +513,10 @@ extension XCUIApplication {
         collectionViews.buttons["Signup"].tap()
 
         sleep(3)
-        buttons["Close"].tap()
+
+        if closeSheet {
+            buttons["Close"].tap()
+        }
     }
 }
+// swiftlint:disable:this file_length

--- a/Tests/UITests/TestAppUITests/FirebaseClient.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseClient.swift
@@ -51,7 +51,7 @@ struct FirestoreAccount: Decodable, Equatable {
 
 
 enum FirebaseClient {
-    private static let projectId = "spezifirebaseuitests"
+    private static let projectId = "nams-e43ed"
 
     // curl -H "Authorization: Bearer owner" -X DELETE http://localhost:9099/emulator/v1/projects/spezifirebaseuitests/accounts
     static func deleteAllAccounts() async throws {

--- a/Tests/UITests/TestAppUITests/FirebaseClient.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseClient.swift
@@ -51,7 +51,7 @@ struct FirestoreAccount: Decodable, Equatable {
 
 
 enum FirebaseClient {
-    private static let projectId = "nams-e43ed"
+    private static let projectId = "spezifirebaseuitests"
 
     // curl -H "Authorization: Bearer owner" -X DELETE http://localhost:9099/emulator/v1/projects/spezifirebaseuitests/accounts
     static func deleteAllAccounts() async throws {

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "df308b8b46607675f2b9ec8e569109008f9155ce",
-        "version" : "1.2022062300.1"
+        "revision" : "748c7837511d0e6a507737353af268484e1745e2",
+        "version" : "1.2024011601.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "3e464dad87dad2d29bb29a97836789bf0f8f67d2",
-        "version" : "10.18.1"
+        "revision" : "076b241a625e25eac22f8849be256dfb960fcdfe",
+        "version" : "10.19.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "be49849dcba96f2b5ee550d4eceb2c0fa27dade4",
-        "version" : "10.22.1"
+        "revision" : "8bcaf973b1d84e119b7c7c119abad72ed460979f",
+        "version" : "10.27.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "482cfa4e5880f0a29f66ecfd60c5a62af28bd1f0",
-        "version" : "10.22.1"
+        "revision" : "70df02431e216bed98dd461e0c4665889245ba70",
+        "version" : "10.27.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "26c898aed8bed13b8a63057ee26500abbbcb8d55",
-        "version" : "7.13.1"
+        "revision" : "57a1d307f42df690fdef2637f3e5b776da02aad6",
+        "version" : "7.13.3"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "ea4cb5cc0c39c732b85386263116d2e2fdbbdc61",
-        "version" : "1.49.2"
+        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+        "version" : "1.62.2"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "76135c9f4e1ac85459d5fec61b6f76ac47ab3a4c",
-        "version" : "3.3.1"
+        "revision" : "0382ca27f22fb3494cf657d8dc356dc282cd1193",
+        "version" : "3.4.1"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
-        "revision" : "43aaef65e0c665daadf848761d560e446d350d3d",
-        "version" : "1.22.4"
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi",
       "state" : {
-        "revision" : "c43e4fa3d3938a847de2b677091a34ddaea5bc76",
-        "version" : "1.2.3"
+        "revision" : "734f90c19422a4196762b0e1dd055471066e89ee",
+        "version" : "1.3.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziAccount",
       "state" : {
-        "revision" : "cb9441e5fe9ca31a17be2507d03817a080e63e9d",
-        "version" : "1.2.2"
+        "revision" : "2de07209430fe7b13c44790eab948b30482fcb9d",
+        "version" : "1.2.4"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
-        "version" : "1.25.2"
+        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
+        "version" : "1.26.0"
       }
     },
     {


### PR DESCRIPTION
# Ensure name is updated after anonymous account linking

## :recycle: Current situation & Problem
As described in #35, the displayName is not updated in the signup code path that handles linking signup credentials with an existing anonymous account.
This PR fixes this issue by updating the display name of the anonymous account if the signup request provides a display name.


## :gear: Release Notes 
* Fixed an issue where the displayName was not updated when signing in by linking against an anonymous user account.


## :books: Documentation
--


## :white_check_mark: Testing
A regression test was added that verifies this behavior.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
