### PR TITLE
Simplifies setData extensions

### DIFF
--- a/Sources/SpeziFirestore/DocumentReference+AsyncAwait.swift
+++ b/Sources/SpeziFirestore/DocumentReference+AsyncAwait.swift
@@ -30,19 +30,8 @@ extension DocumentReference {
         encoder: FirebaseFirestore.Firestore.Encoder = FirebaseFirestore.Firestore.Encoder()
     ) async throws {
         do {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                do {
-                    let encoded = try encoder.encode(value)
-                    setData(encoded) { error in
-                        if let error {
-                            continuation.resume(throwing: error)
-                        }
-                        continuation.resume()
-                    }
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
+            let encoded = try encoder.encode(value)
+            try await setData(encoded)
         } catch {
             throw FirestoreError(error)
         }
@@ -69,19 +58,8 @@ extension DocumentReference {
         encoder: FirebaseFirestore.Firestore.Encoder = FirebaseFirestore.Firestore.Encoder()
     ) async throws {
         do {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                do {
-                    let encoded = try encoder.encode(value)
-                    setData(encoded, merge: merge) { error in
-                        if let error {
-                            continuation.resume(throwing: error)
-                        }
-                        continuation.resume()
-                    }
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
+            let encoded = try encoder.encode(value)
+            try await setData(encoded, merge: merge)
         } catch {
             throw FirestoreError(error)
         }
@@ -112,19 +90,8 @@ extension DocumentReference {
         encoder: FirebaseFirestore.Firestore.Encoder = FirebaseFirestore.Firestore.Encoder()
     ) async throws {
         do {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                do {
-                    let encoded = try encoder.encode(value)
-                    setData(encoded, mergeFields: mergeFields) { error in
-                        if let error {
-                            continuation.resume(throwing: error)
-                        }
-                        continuation.resume()
-                    }
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
+            let encoded = try encoder.encode(value)
+            try await setData(encoded, mergeFields: mergeFields)
         } catch {
             throw FirestoreError(error)
         }

--- a/Tests/UITests/TestApp/FirestoreDataStorageTests/FirestoreDataStorageTests.swift
+++ b/Tests/UITests/TestApp/FirestoreDataStorageTests/FirestoreDataStorageTests.swift
@@ -32,14 +32,17 @@ struct FirestoreDataStorageTestsView: View {
                     prompt: Text("Enter the element's identifier.")
                 )
                 TextField(
-                    "Context",
+                    "Content",
                     text: $element.content,
-                    prompt: Text("Enter the element's optional context.")
+                    prompt: Text("Enter the element's optional content.")
                 )
             }
             Section("Actions") {
                 Button("Upload Element") {
                     uploadElement()
+                }
+                Button("Merge Element") {
+                    mergeElement()
                 }
                 Button(
                     role: .destructive,
@@ -63,13 +66,38 @@ struct FirestoreDataStorageTestsView: View {
         viewState = .processing
         Task {
             do {
-                try await Firestore.firestore().collection("Test").document(element.id).setData(from: element)
+                try await Firestore
+                    .firestore()
+                    .collection("Test")
+                    .document(element.id)
+                    .setData(from: element)
                 viewState = .idle
             } catch {
                 viewState = .error(FirestoreError(error))
             }
         }
     }
+    
+    @MainActor
+    private func mergeElement() {
+        viewState = .processing
+        Task {
+            do {
+                try await Firestore
+                    .firestore()
+                    .collection("Test")
+                    .document(element.id)
+                    .setData(
+                        from: element,
+                        merge: true
+                    )
+                viewState = .idle
+            } catch {
+                viewState = .error(FirestoreError(error))
+            }
+        }
+    }
+
     
     @MainActor
     private func deleteElement() {

--- a/Tests/UITests/TestAppUITests/FirestoreDataStorageTests.swift
+++ b/Tests/UITests/TestAppUITests/FirestoreDataStorageTests.swift
@@ -66,7 +66,31 @@ final class FirestoreDataStorageTests: XCTestCase {
         var documents = try await getAllDocuments()
         XCTAssert(documents.isEmpty)
         
-        try add(id: "Identifier1", context: "1")
+        try add(id: "Identifier1", content: "1")
+        
+        try await Task.sleep(for: .seconds(0.5))
+        documents = try await getAllDocuments()
+        XCTAssertEqual(
+            documents.sorted(by: { $0.name < $1.name }),
+            [
+                FirestoreElement(
+                    id: "Identifier1",
+                    content: "1"
+                )
+            ]
+        )
+    }
+    
+    @MainActor
+    func testFirestoreMerge() async throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.buttons["FirestoreDataStorage"].tap()
+        
+        var documents = try await getAllDocuments()
+        XCTAssert(documents.isEmpty)
+        
+        try merge(id: "Identifier1", content: "1")
         
         try await Task.sleep(for: .seconds(0.5))
         documents = try await getAllDocuments()
@@ -90,7 +114,7 @@ final class FirestoreDataStorageTests: XCTestCase {
         var documents = try await getAllDocuments()
         XCTAssert(documents.isEmpty)
         
-        try add(id: "Identifier1", context: "1")
+        try add(id: "Identifier1", content: "1")
         
         try await Task.sleep(for: .seconds(0.5))
         documents = try await getAllDocuments()
@@ -104,7 +128,7 @@ final class FirestoreDataStorageTests: XCTestCase {
             ]
         )
         
-        try add(id: "Identifier1", context: "2")
+        try add(id: "Identifier1", content: "2")
         
         try await Task.sleep(for: .seconds(0.5))
         documents = try await getAllDocuments()
@@ -129,7 +153,7 @@ final class FirestoreDataStorageTests: XCTestCase {
         var documents = try await getAllDocuments()
         XCTAssert(documents.isEmpty)
         
-        try add(id: "Identifier1", context: "1")
+        try add(id: "Identifier1", content: "1")
         
         try await Task.sleep(for: .seconds(0.5))
         documents = try await getAllDocuments()
@@ -143,33 +167,38 @@ final class FirestoreDataStorageTests: XCTestCase {
             ]
         )
         
-        try remove(id: "Identifier1", context: "1")
+        try remove(id: "Identifier1", content: "1")
         
         documents = try await getAllDocuments()
         XCTAssert(documents.isEmpty)
     }
     
     
-    private func add(id: String, context: String) throws {
-        try enterFirestoreElement(id: id, context: context)
+    private func add(id: String, content: String) throws {
+        try enterFirestoreElement(id: id, content: content)
         XCUIApplication().buttons["Upload Element"].tap()
     }
     
-    private func remove(id: String, context: String) throws {
-        try enterFirestoreElement(id: id, context: context)
+    private func merge(id: String, content: String) throws {
+        try enterFirestoreElement(id: id, content: content)
+        XCUIApplication().buttons["Merge Element"].tap()
+    }
+    
+    private func remove(id: String, content: String) throws {
+        try enterFirestoreElement(id: id, content: content)
         XCUIApplication().buttons["Delete Element"].tap()
     }
     
-    private func enterFirestoreElement(id: String, context: String) throws {
+    private func enterFirestoreElement(id: String, content: String) throws {
         let app = XCUIApplication()
         
         let identifierTextFieldIdentifier = "Enter the element's identifier."
         try app.textFields[identifierTextFieldIdentifier].delete(count: 42)
         try app.textFields[identifierTextFieldIdentifier].enter(value: id)
         
-        let contextFieldIdentifier = "Enter the element's optional context."
-        try app.textFields[contextFieldIdentifier].delete(count: 100)
-        try app.textFields[contextFieldIdentifier].enter(value: context)
+        let contentFieldIdentifier = "Enter the element's optional content."
+        try app.textFields[contentFieldIdentifier].delete(count: 100)
+        try app.textFields[contentFieldIdentifier].enter(value: content)
     }
     
     private func deleteAllDocuments() async throws {


### PR DESCRIPTION
# Simplifies setData extensions

## :recycle: Current situation & Problem
This setData extensions can be simplified to remove the continuations as the Firebase SDK now provides an async function for saving a dictionary to Firestore. This may also resolve the bug reported in #37, as the continuation is now removed.

## :gear: Release Notes 
Updates the setData extensions to use the async function as described above.

## :books: Documentation
The function signatures are unchanged and no changes to documentation are required.


## :white_check_mark: Testing
Additional tests have been added.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
