### PR TITLE
Avoid Setting Data When No Data is Provided

### DIFF
--- a/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
+++ b/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
@@ -90,6 +90,10 @@ public actor FirestoreAccountStorage: Module, AccountStorageConstraint {
         do {
             switch result {
             case let .success(data):
+                guard !data.isEmpty else {
+                    return
+                }
+                
                 try await userDocument(for: identifier.accountId)
                     .setData(data, merge: true)
             case let .failure(error):
@@ -137,7 +141,7 @@ public actor FirestoreAccountStorage: Module, AccountStorageConstraint {
             switch result {
             case let .success(data):
                 try await userDocument(for: identifier.accountId)
-                    .setData(data, merge: true)
+                    .updateData(data)
             case let .failure(error):
                 throw error
             }


### PR DESCRIPTION
# Avoid Setting Data when no Data is Provided

## :recycle: Current situation & Problem
- SpeziFirebase tries to write a document when no data should be created which can clash with possible security rules not allowing deletion.
- No document should be created on updating elements.

## :gear: Release Notes 
- Avoid Setting Data When No Data is Provided


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
