### PR TITLE
Support new `CodableWithConfiguration` conformance of `AccountDetails`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.6.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", exact: "2.0.0-beta.4"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", branch: "feature/accountdetails-coding-configuration"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "11.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0")
     ] + swiftLintPackage(),

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.6.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", branch: "feature/accountdetails-coding-configuration"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", exact: "2.0.0-beta.5"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "11.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0")
     ] + swiftLintPackage(),

--- a/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
+++ b/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
@@ -18,7 +18,8 @@ private struct AccountDetailsConfiguration: DecodingConfigurationProviding, Enco
 }
 
 
-// Firebase doesn't support DecodableWithConfiguration yet. So that's our workaround
+// Firebase doesn't support DecodableWithConfiguration yet. So that's our workaround.
+// Feature is tracked as https://github.com/firebase/firebase-ios-sdk/issues/13552
 private struct AccountDetailsWrapper: Codable {
     let details: AccountDetails
 

--- a/Tests/UITests/TestAppUITests/FirebaseClient.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseClient.swift
@@ -51,7 +51,7 @@ struct FirestoreAccount: Decodable, Equatable {
 
 
 enum FirebaseClient {
-    private static let projectId = "spezifirebaseuitests"
+    private static let projectId = "nams-e43ed"
 
     // curl -H "Authorization: Bearer owner" -X DELETE http://localhost:9099/emulator/v1/projects/spezifirebaseuitests/accounts
     static func deleteAllAccounts() async throws {

--- a/Tests/UITests/TestAppUITests/FirebaseClient.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseClient.swift
@@ -51,7 +51,7 @@ struct FirestoreAccount: Decodable, Equatable {
 
 
 enum FirebaseClient {
-    private static let projectId = "nams-e43ed"
+    private static let projectId = "spezifirebaseuitests"
 
     // curl -H "Authorization: Bearer owner" -X DELETE http://localhost:9099/emulator/v1/projects/spezifirebaseuitests/accounts
     static func deleteAllAccounts() async throws {

--- a/Tests/UITests/TestAppUITests/FirestoreDataStorageTests.swift
+++ b/Tests/UITests/TestAppUITests/FirestoreDataStorageTests.swift
@@ -195,12 +195,12 @@ final class FirestoreDataStorageTests: XCTestCase {
         let app = XCUIApplication()
         
         let identifierTextFieldIdentifier = "Enter the element's identifier."
-        try app.textFields[identifierTextFieldIdentifier].delete(count: 42)
-        try app.textFields[identifierTextFieldIdentifier].enter(value: id)
-        
+        try app.textFields[identifierTextFieldIdentifier].delete(count: 42, options: .disableKeyboardDismiss)
+        try app.textFields[identifierTextFieldIdentifier].enter(value: id, options: .skipTextFieldSelection)
+
         let contentFieldIdentifier = "Enter the element's optional content."
-        try app.textFields[contentFieldIdentifier].delete(count: 100)
-        try app.textFields[contentFieldIdentifier].enter(value: content)
+        try app.textFields[contentFieldIdentifier].delete(count: 100, options: .disableKeyboardDismiss)
+        try app.textFields[contentFieldIdentifier].enter(value: content, options: .skipTextFieldSelection)
     }
 }
 


### PR DESCRIPTION
# Support new `CodableWithConfiguration` conformance of `AccountDetails`

## :recycle: Current situation & Problem
This PR updates to the latest `SpeziAccount` release that migrated `AccountDetails` to adopt the new `CodableWithConfiguration` protocols replacing the previous `userInfo`-based approach of passing additional configuration for encoding and decoding.

## :gear: Release Notes 
* Update to the new SpeziAccount beta release.


## :books: Documentation
--


## :white_check_mark: Testing
Existing unit tests cover these modifications.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
