### PR TITLE
Make sure SnapshotListener on Account is actually added

### DIFF
--- a/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
+++ b/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
@@ -196,7 +196,7 @@ public actor FirestoreAccountStorage: AccountStorageProvider {
         let localCache = localCache
         let cached = await localCache.loadEntry(for: accountId, keys)
 
-        if listenerRegistrations[accountId] != nil { // check that there is a snapshot listener in place
+        if listenerRegistrations[accountId] == nil { // check that there is a snapshot listener in place
             snapshotListener(for: accountId, with: keys)
         }
 


### PR DESCRIPTION
# Make sure SnapshotListener on Account is actually added

## :recycle: Current situation & Problem
I noticed that there actually never is a snapshot listener on Account. I found out that it is only added in the function `FirestoreAccountStorage.snapshotListener(for:with:)`, which previously only created a snapshot listener, if there already is one - so never. Changing the operator will solve the problem and makes sure that we add the snapshot listener when needed.


## :gear: Release Notes 
- Make sure to add snapshot listener on Account.


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
