### PR TITLE
Make sure currentUser is available upon startup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.6.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziAccount", from: "2.1.1"),
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "11.0.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "11.8.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0")
     ] + swiftLintPackage(),
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -26,10 +26,10 @@ let package = Package(
         .library(name: "SpeziFirebaseAccountStorage", targets: ["SpeziFirebaseAccountStorage"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0"),
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.6.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", from: "2.1.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.1.0"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.8.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.9.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziAccount", from: "2.1.2"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "11.8.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0")
     ] + swiftLintPackage(),

--- a/Sources/SpeziFirebaseAccount/FirebaseAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/FirebaseAccountService.swift
@@ -247,11 +247,10 @@ public final class FirebaseAccountService: AccountService { // swiftlint:disable
             }
         }
 
-        // The `Auth.auth().currentUser` is not available immediately. The init of `Auth` delays
-        // the retrieval of the keychain object.
-        // See https://github.com/firebase/firebase-ios-sdk/blob/main/FirebaseAuth/Sources/Swift/Auth/Auth.swift#L1646.
-        // To increase our chance that the initial check did run, we move this check to the end.
-        // Every call to Auth.auth() acquires a lock, so this might increase our chance that the initialization did complete successfully.
+        // Firebase v11.6.0 restore the v10 behavior where the currentUser is available immediately after startup.
+        // `currentUser` will sync to the Auth worker queue, see https://github.com/firebase/firebase-ios-sdk/pull/14141.
+        // The Auth.init kicked off loading the current user already above, so we might not need to wait that long here.
+        // But, if there is a user, it will definitely get loaded here.
         checkForInitialUserAccount()
 
         Task.detached { [logger, secureStorage, localStorage] in

--- a/Tests/UITests/TestApp/FirebaseAccountTests/FirebaseAccountTestsView.swift
+++ b/Tests/UITests/TestApp/FirebaseAccountTests/FirebaseAccountTestsView.swift
@@ -17,6 +17,8 @@ import SwiftUI
 struct FirebaseAccountTestsView: View {
     @Environment(Account.self)
     var account
+    @Environment(AccountTestModel.self)
+    private var testModel
 
     @State var viewState: ViewState = .idle
 
@@ -26,6 +28,9 @@ struct FirebaseAccountTestsView: View {
 
     var body: some View {
         List {
+            Section {
+                ListRow("User Present on Startup", value: testModel.accountUponConfigure ? "Yes" : "No")
+            }
             if let details = account.details {
                 Section {
                     accountHeader(for: details)
@@ -96,3 +101,16 @@ struct FirebaseAccountTestsView: View {
         }
     }
 }
+
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        FirebaseAccountTestsView()
+    }
+        .environment(AccountTestModel())
+        .previewWith {
+            AccountConfiguration(service: InMemoryAccountService(), configuration: .default)
+        }
+}
+#endif

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -17,7 +17,29 @@ import SpeziFirestore
 import SwiftUI
 
 
+@Observable
+final class AccountTestModel {
+    /// Flag to determine if an account was present upon the initial startup.
+    var accountUponConfigure = false
+
+    init() {}
+}
+
+
 class TestAppDelegate: SpeziAppDelegate {
+    private class InitialUserCheck: Module {
+        @Dependency(Account.self)
+        private var account
+        @Dependency(FirebaseAccountService.self)
+        private var service
+
+        @Model var model = AccountTestModel()
+
+        func configure() {
+            model.accountUponConfigure = account.signedIn
+        }
+    }
+
     private class Logout: Module {
         @Application(\.logger)
         private var logger
@@ -70,6 +92,8 @@ class TestAppDelegate: SpeziAppDelegate {
             }
 
             Logout()
+
+            InitialUserCheck()
 
             Firestore(settings: .emulator)
             FirebaseStorageConfiguration(emulatorSettings: (host: "localhost", port: 9199))

--- a/Tests/UITests/TestAppUITests/FirebaseClient.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseClient.swift
@@ -51,7 +51,7 @@ struct FirestoreAccount: Decodable, Equatable {
 
 
 enum FirebaseClient {
-    private static let projectId = "spezifirebaseuitests"
+    private static let projectId = "nams-e43ed"
 
     // curl -H "Authorization: Bearer owner" -X DELETE http://localhost:9099/emulator/v1/projects/spezifirebaseuitests/accounts
     static func deleteAllAccounts() async throws {

--- a/Tests/UITests/TestAppUITests/FirebaseClient.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseClient.swift
@@ -51,7 +51,7 @@ struct FirestoreAccount: Decodable, Equatable {
 
 
 enum FirebaseClient {
-    private static let projectId = "nams-e43ed"
+    private static let projectId = "spezifirebaseuitests"
 
     // curl -H "Authorization: Bearer owner" -X DELETE http://localhost:9099/emulator/v1/projects/spezifirebaseuitests/accounts
     static func deleteAllAccounts() async throws {


### PR DESCRIPTION
# Make sure currentUser is available upon startup

## :recycle: Current situation & Problem
We experience problems, where the Firebase `currentUser` was not directly available upon startup and therefore required busy-waiting approaches to make sure a firebase user is available on startup actions (e.g., see https://github.com/StanfordBDHG/PediatricAppleWatchStudy/pull/83#discussion_r1936199855).
Firebase [v11.6.0](https://github.com/firebase/firebase-ios-sdk/releases/tag/11.6.0) fixes this issue with https://github.com/firebase/firebase-ios-sdk/pull/14141, making sure that the `currentUser` is available immediately. We raise the minimum required Firebase version to the latest one and updated our code comments.

## :gear: Release Notes 
* Fixed an issue where the user account might not be available immediately.
* Raised minimum required Firebase SDK


## :books: Documentation
Updated inline docs.

## :white_check_mark: Testing
Added UI test to verify that user account is available inside `configure()` if user is logged in.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
