### PR TITLE
try to revert to the XCTExtensions-based text entry

### DIFF
--- a/Tests/UITests/TestAppUITests/FirestoreDataStorageTests.swift
+++ b/Tests/UITests/TestAppUITests/FirestoreDataStorageTests.swift
@@ -200,7 +200,7 @@ final class FirestoreDataStorageTests: XCTestCase {
 
         let contentFieldIdentifier = "Enter the element's optional content."
         try app.textFields[contentFieldIdentifier].delete(count: 100, options: .disableKeyboardDismiss)
-        app.textFields[contentFieldIdentifier].typeText(content)
+        try app.textFields[contentFieldIdentifier].enter(value: content, options: .skipTextFieldSelection)
     }
 }
 


### PR DESCRIPTION
# try to revert to the XCTExtensions-based text entry

## :recycle: Current situation & Problem
Text entry for the `FirestoreDataStorageTests` test case is unreliable for some reason (it sometimes enters text twice; eg we want it to type `1`, but end up with `11`.

## :gear: Release Notes 
n/a

## :books: Documentation
n/a

## :white_check_mark: Testing
hopefully better

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
