### PR TITLE
allow specifying a custom configuration

### DIFF
--- a/Sources/SpeziFirebaseConfiguration/ConfigureFirebaseApp.swift
+++ b/Sources/SpeziFirebaseConfiguration/ConfigureFirebaseApp.swift
@@ -16,7 +16,7 @@ import Spezi
 /// The `FirebaseApp.configure()` method will be called upon configuration of the `Module`.
 ///
 /// If your app uses the standard `GoogleService-Info.plist` approach to configure Firebase, you don't need to explicitly enable this module.
-/// However, if you want to use a custom, non-plist-based Firebase configuration, you should place t
+/// However, if you want to use a custom, non-plist-based Firebase configuration, you should place this module into your Spezi app's Configuration.
 ///
 /// Use the `@Dependency` property wrapper to define a dependency on this module and ensure that `FirebaseApp.configure()` is called before any
 /// other Firebase-related modules and to ensure it is called exactly once.

--- a/Sources/SpeziFirebaseConfiguration/ConfigureFirebaseApp.swift
+++ b/Sources/SpeziFirebaseConfiguration/ConfigureFirebaseApp.swift
@@ -7,12 +7,16 @@
 //
 
 import FirebaseCore
+import FirebaseCoreExtension
 import Spezi
 
 
 /// Configure the Firebase application.
 ///
 /// The `FirebaseApp.configure()` method will be called upon configuration of the `Module`.
+///
+/// If your app uses the standard `GoogleService-Info.plist` approach to configure Firebase, you don't need to explicitly enable this module.
+/// However, if you want to use a custom, non-plist-based Firebase configuration, you should place t
 ///
 /// Use the `@Dependency` property wrapper to define a dependency on this module and ensure that `FirebaseApp.configure()` is called before any
 /// other Firebase-related modules and to ensure it is called exactly once.
@@ -27,10 +31,61 @@ import Spezi
 /// }
 /// ```
 public final class ConfigureFirebaseApp: Module, DefaultInitializable {
-    public init() {}
+    private enum Input {
+        case useDefault
+        case custom(name: String, options: FirebaseOptions)
+    }
     
+    /// Whether any instance of this module was already configured.
+    /// We use this property to keep track of this, since Firebase doesn't allow repeated configuration.
+    @MainActor private static var didConfigure = false
     
+    @MainActor private static var usedConfigInput: Input?
+    
+    // TODO: document!
+    @MainActor private static var isDefaultConfigurationAllowed = true
+    
+    @MainActor public static func disallowDefaultConfiguration() {
+        isDefaultConfigurationAllowed = false
+    }
+    
+    @Application(\.logger)
+    private var logger
+    
+    private let input: Input
+    
+    /// Creates a ``ConfigureFirebaseApp`` instance, which will configure firebase based on the contents of the `GoogleService-Info.plist` file.
+    public init() {
+        input = .useDefault
+    }
+    
+    /// Creates a ``ConfigureFirebaseApp`` instance, which will configure firebase using custom configuration options.
+    /// - parameter name: The name of the app. Defaults to `__FIRAPP_DEFAULT`.
+    /// - parameter options: The options which should be used to configure firebase.
+    public init(name: String = kFIRDefaultAppName, options: FirebaseOptions) {
+        input = .custom(name: name, options: options)
+    }
+    
+    @_documentation(visibility: internal)
     public func configure() {
-        FirebaseApp.configure()
+        if let lastInput = Self.usedConfigInput {
+            preconditionFailure("Firebase was already configured, using \(lastInput)")
+        }
+        guard !Self.didConfigure else {
+            preconditionFailure("\(Self.self) module was included multiple times in Spezi Configuration")
+        }
+        switch input {
+        case .useDefault:
+            guard Self.isDefaultConfigurationAllowed else {
+                preconditionFailure("Attempted to configure default config, which is disallowed.")
+            }
+            logger.notice("Configuring Firebase using default config")
+            Self.usedConfigInput = input
+            FirebaseApp.configure()
+        case let .custom(name, options):
+            logger.notice("Configuring Firebase using custom config; name=\(name); options=\(options)")
+            Self.usedConfigInput = input
+            FirebaseApp.configure(name: name, options: options)
+        }
     }
 }

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -65,16 +65,18 @@ class TestAppDelegate: SpeziAppDelegate {
 
     override var configuration: Configuration {
         Configuration {
-            let configuration: AccountValueConfiguration = FeatureFlags.accountStorageTests
-            ? [
-                .requires(\.userId),
-                .requires(\.name),
-                .requires(\.biography)
-            ]
-            : [
-                .requires(\.userId),
-                .collects(\.name)
-            ]
+            let configuration: AccountValueConfiguration = if FeatureFlags.accountStorageTests {
+                [
+                    .requires(\.userId),
+                    .requires(\.name),
+                    .requires(\.biography)
+                ]
+            } else {
+                [
+                    .requires(\.userId),
+                    .collects(\.name)
+                ]
+            }
 
             let service = FirebaseAccountService(
                 providers: [.emailAndPassword, .signInWithApple, .anonymousButton],


### PR DESCRIPTION
# allow specifying a custom configuration

## :recycle: Current situation & Problem
Currently, the ConfigureFirebaseApp, always uses the default `GoogleService-Info.plist` file.
This PR allows spezifying a custom `FirebaseOptions` object which will be used instead.

## :gear: Release Notes
Add option to specify custom firebase options.

## :books: Documentation
has been updated

## :white_check_mark: Testing
since this PR isn't exactly adding logic, and is just adding a new means of forwarding data into a firebase API function call, there is no new test.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
