### PR TITLE
Custom Encoder/Decoder Configuration for FirestoreAccountStorage

### DIFF
--- a/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
+++ b/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
@@ -111,7 +111,7 @@ public actor FirestoreAccountStorage: AccountStorageProvider {
     ///
     /// ### Custom Encoder/Decoder Configuration
     ///
-    /// For advanced use cases, such as integrating with libraries like PhoneNumberKit that require specific encoding/decoding strategies,
+    /// For advanced use cases, such as integrating with libraries like PhoneNumberKit where you might want to set specific encoding/decoding strategies,
     /// you can provide custom encoder and decoder instances with specific userInfo configurations.
     ///
     /// ```swift

--- a/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
+++ b/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
@@ -140,13 +140,13 @@ public actor FirestoreAccountStorage: AccountStorageProvider {
     public init(
         storeIn collection: @Sendable @autoclosure @escaping () -> CollectionReference,
         mapping identifierMapping: [String: any AccountKey.Type]? = nil, // swiftlint:disable:this discouraged_optional_collection
-        encoder: FirebaseFirestore.Firestore.Encoder? = nil,
-        decoder: FirebaseFirestore.Firestore.Decoder? = nil
+        encoder: FirebaseFirestore.Firestore.Encoder = FirebaseFirestore.Firestore.Encoder(),
+        decoder: FirebaseFirestore.Firestore.Decoder = FirebaseFirestore.Firestore.Decoder()
     ) {
         self.collection = collection // make it a auto-closure. Firestore.firstore() is only configured later on
         self.identifierMapping = identifierMapping
-        self.encoder = encoder ?? FirebaseFirestore.Firestore.Encoder()
-        self.decoder = decoder ?? FirebaseFirestore.Firestore.Decoder()
+        self.encoder = encoder
+        self.decoder = decoder
     }
 
 

--- a/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
+++ b/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
@@ -121,7 +121,7 @@ public actor FirestoreAccountStorage: AccountStorageProvider {
     /// encoder.userInfo[.phoneNumbers] = PhoneNumberEncodingStrategy.e164
     ///
     /// let decoder = Firestore.Decoder()
-    /// decoder.userInfo[.phoneNumbers] = PhoneNumberEncodingStrategy.e164
+    /// decoder.userInfo[.phoneNumbers] = PhoneNumberDecodingStrategy.e164
     ///
     /// let storage = FirestoreAccountStorage(
     ///     storeIn: Firestore.firestore().collection("users"),

--- a/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
+++ b/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
@@ -115,19 +115,34 @@ public actor FirestoreAccountStorage: AccountStorageProvider {
     /// you can provide custom encoder and decoder instances with specific userInfo configurations.
     ///
     /// ```swift
-    /// import PhoneNumberKit
+    /// private let customEncoder: FirebaseFirestore.Firestore.Encoder {
+    ///     let encoder = FirebaseFirestore.Firestore.Encoder()
+    ///     encoder.userInfo[.phoneNumberEncodingStrategy] = PhoneNumberDecodingStrategy.e164
+    ///     return encoder
+    /// }
     ///
-    /// let encoder = FirebaseFirestore.Firestore.Encoder()
-    /// encoder.userInfo[CodingUserInfoKey(rawValue: "com.roymarmelstein.PhoneNumberKit.encoding-strategy")!] = PhoneNumberEncodingStrategy.e164
+    /// private let customDecoder: FirebaseFirestore.Firestore.Decoder {
+    ///     let decoder = FirebaseFirestore.Firestore.Decoder()
+    ///     decoder.userInfo[.phoneNumberDecodingStrategy] = PhoneNumberDecodingStrategy.e164
+    ///     return decoder
+    /// }
     ///
-    /// let decoder = FirebaseFirestore.Firestore.Decoder()
-    /// decoder.userInfo[CodingUserInfoKey(rawValue: "com.roymarmelstein.PhoneNumberKit.decoding-strategy")!] = PhoneNumberDecodingStrategy.e164
-    ///
-    /// let storage = FirestoreAccountStorage(
-    ///     storeIn: Firestore.firestore().collection("users"),
-    ///     encoder: encoder,
-    ///     decoder: decoder
-    /// )
+    /// override var configuration: Configuration {
+    ///     Configuration(standard: YourStandard()) {
+    ///         AccountConfiguration(
+    ///             storageProvider: FirestoreAccountStorage(
+    ///                 storeIn: Firestore.userCollection,
+    ///                 mapping: [
+    ///                     "phoneNumbers": AccountKeys.phoneNumbers,
+    ///                     // ... other mappings ...
+    ///                 ],
+    ///                 encoder: customEncoder,
+    ///                 decoder: customDecoder
+    ///             ),
+    ///         // ... other configuration ...
+    ///         )
+    ///     }
+    /// }
     /// ```
     ///
     /// - Parameters:

--- a/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
+++ b/Sources/SpeziFirebaseAccountStorage/FirestoreAccountStorage.swift
@@ -92,8 +92,8 @@ public actor FirestoreAccountStorage: AccountStorageProvider {
 
     private let collection: @Sendable () -> CollectionReference
     private let identifierMapping: [String: any AccountKey.Type]? // swiftlint:disable:this discouraged_optional_collection
-    private let encoder: Firestore.Encoder
-    private let decoder: Firestore.Decoder
+    private let encoder: FirebaseFirestore.Firestore.Encoder
+    private let decoder: FirebaseFirestore.Firestore.Decoder
 
     private var listenerRegistrations: [String: any ListenerRegistration] = [:]
     private var registeredKeys: [String: [ObjectIdentifier: any AccountKey.Type]] = [:]
@@ -117,11 +117,11 @@ public actor FirestoreAccountStorage: AccountStorageProvider {
     /// ```swift
     /// import PhoneNumberKit
     ///
-    /// let encoder = Firestore.Encoder()
-    /// encoder.userInfo[.phoneNumbers] = PhoneNumberEncodingStrategy.e164
+    /// let encoder = FirebaseFirestore.Firestore.Encoder()
+    /// encoder.userInfo[CodingUserInfoKey(rawValue: "com.roymarmelstein.PhoneNumberKit.encoding-strategy")!] = PhoneNumberEncodingStrategy.e164
     ///
-    /// let decoder = Firestore.Decoder()
-    /// decoder.userInfo[.phoneNumbers] = PhoneNumberDecodingStrategy.e164
+    /// let decoder = FirebaseFirestore.Firestore.Decoder()
+    /// decoder.userInfo[CodingUserInfoKey(rawValue: "com.roymarmelstein.PhoneNumberKit.decoding-strategy")!] = PhoneNumberDecodingStrategy.e164
     ///
     /// let storage = FirestoreAccountStorage(
     ///     storeIn: Firestore.firestore().collection("users"),
@@ -140,13 +140,13 @@ public actor FirestoreAccountStorage: AccountStorageProvider {
     public init(
         storeIn collection: @Sendable @autoclosure @escaping () -> CollectionReference,
         mapping identifierMapping: [String: any AccountKey.Type]? = nil, // swiftlint:disable:this discouraged_optional_collection
-        encoder: Firestore.Encoder? = nil,
-        decoder: Firestore.Decoder? = nil
+        encoder: FirebaseFirestore.Firestore.Encoder? = nil,
+        decoder: FirebaseFirestore.Firestore.Decoder? = nil
     ) {
         self.collection = collection // make it a auto-closure. Firestore.firstore() is only configured later on
         self.identifierMapping = identifierMapping
-        self.encoder = encoder ?? Firestore.Encoder()
-        self.decoder = decoder ?? Firestore.Decoder()
+        self.encoder = encoder ?? FirebaseFirestore.Firestore.Encoder()
+        self.decoder = decoder ?? FirebaseFirestore.Firestore.Decoder()
     }
 
 

--- a/Sources/SpeziFirebaseAccountStorage/SpeziFirebaseAccountStorage.docc/SpeziFirebaseAccountStorage.md
+++ b/Sources/SpeziFirebaseAccountStorage/SpeziFirebaseAccountStorage.docc/SpeziFirebaseAccountStorage.md
@@ -36,15 +36,36 @@ import SpeziFirebaseAccount
 import SpeziFirebaseAccountStorage
 
 class ExampleAppDelegate: SpeziAppDelegate {
-override var configuration: Configuration {
-    Configuration {
-        AccountConfiguration(
-            service: FirebaseAccountService(),
-            storageProvider: FirestoreAccountStorage(storeIn: Firestore.firestore().collection("users"))
-            configuration: [/* ... */]
-        )
+    override var configuration: Configuration {
+        Configuration {
+            AccountConfiguration(
+                service: FirebaseAccountService(),
+                storageProvider: FirestoreAccountStorage(storeIn: Firestore.firestore().collection("users")),
+                configuration: [/* ... */]
+            )
+        }
     }
 }
+
+### Custom Encoder/Decoder Configuration
+
+For advanced use cases, such as integrating with libraries like PhoneNumberKit where you might want to set specific encoding/decoding strategies,
+you can provide custom encoder and decoder instances with specific userInfo configurations.
+
+```swift
+import PhoneNumberKit
+
+let encoder = FirebaseFirestore.Firestore.Encoder()
+encoder.userInfo[CodingUserInfoKey(rawValue: "com.roymarmelstein.PhoneNumberKit.encoding-strategy")!] = PhoneNumberEncodingStrategy.e164
+
+let decoder = FirebaseFirestore.Firestore.Decoder()
+decoder.userInfo[CodingUserInfoKey(rawValue: "com.roymarmelstein.PhoneNumberKit.decoding-strategy")!] = PhoneNumberDecodingStrategy.e164
+
+let storage = FirestoreAccountStorage(
+    storeIn: Firestore.firestore().collection("users"),
+    encoder: encoder,
+    decoder: decoder
+)
 ```
 
 > Important: In order to use the `FirestoreAccountStorage`, you must have [`Firestore`](https://swiftpackageindex.com/stanfordspezi/spezifirebase/main/documentation/spezifirestore/firestore)

--- a/Sources/SpeziFirebaseAccountStorage/SpeziFirebaseAccountStorage.docc/SpeziFirebaseAccountStorage.md
+++ b/Sources/SpeziFirebaseAccountStorage/SpeziFirebaseAccountStorage.docc/SpeziFirebaseAccountStorage.md
@@ -53,19 +53,34 @@ For advanced use cases, such as integrating with libraries like PhoneNumberKit w
 you can provide custom encoder and decoder instances with specific userInfo configurations.
 
 ```swift
-import PhoneNumberKit
+private let customEncoder: FirebaseFirestore.Firestore.Encoder {
+    let encoder = FirebaseFirestore.Firestore.Encoder()
+    encoder.userInfo[.phoneNumberEncodingStrategy] = PhoneNumberDecodingStrategy.e164
+    return encoder
+}
 
-let encoder = FirebaseFirestore.Firestore.Encoder()
-encoder.userInfo[CodingUserInfoKey(rawValue: "com.roymarmelstein.PhoneNumberKit.encoding-strategy")!] = PhoneNumberEncodingStrategy.e164
+private let customDecoder: FirebaseFirestore.Firestore.Decoder {
+    let decoder = FirebaseFirestore.Firestore.Decoder()
+    decoder.userInfo[.phoneNumberDecodingStrategy] = PhoneNumberDecodingStrategy.e164
+    return decoder
+}
 
-let decoder = FirebaseFirestore.Firestore.Decoder()
-decoder.userInfo[CodingUserInfoKey(rawValue: "com.roymarmelstein.PhoneNumberKit.decoding-strategy")!] = PhoneNumberDecodingStrategy.e164
-
-let storage = FirestoreAccountStorage(
-    storeIn: Firestore.firestore().collection("users"),
-    encoder: encoder,
-    decoder: decoder
-)
+override var configuration: Configuration {
+    Configuration(standard: YourStandard()) {
+        AccountConfiguration(
+            storageProvider: FirestoreAccountStorage(
+                storeIn: Firestore.userCollection,
+                mapping: [
+                    "phoneNumbers": AccountKeys.phoneNumbers,
+                    // ... other mappings ...
+                ],
+                encoder: customEncoder,
+                decoder: customDecoder
+            ),
+        // ... other configuration ...
+        )
+    }
+}
 ```
 
 > Important: In order to use the `FirestoreAccountStorage`, you must have [`Firestore`](https://swiftpackageindex.com/stanfordspezi/spezifirebase/main/documentation/spezifirestore/firestore)


### PR DESCRIPTION
# *Custom Encoder/Decoder Configuration for FirestoreAccountStorage*

## :recycle: Current situation & Problem

Currently, the `FirestoreAccountStorage` creates new `Firestore.Encoder` and `Firestore.Decoder` instances for each encoding/decoding operation, without any way to configure them with custom `userInfo` settings. This limits integration with libraries like PhoneNumberKit where you might want to set specific encoding/decoding strategies (e.g., E164 format) from the client application.

## :gear: Release Notes
- Custom encoder/decoder configuration support in `FirestoreAccountStorage` initializer with optional `encoder` and `decoder` parameters to allow custom `Firestore.Encoder` and `Firestore.Decoder` instances with specific `userInfo` configurations
- Backward compatibility - existing code continues to work without changes
- Encoder/decoder instances are now stored as constants instead of being recreated for each operation

## :books: Documentation
- Added PhoneNumberKit integration example demonstrating E164 format configuration
- Updated parameter documentation to explain the new optional `encoder` and `decoder` parameters


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
