### PR TITLE
Handle & Invalidate Active User Sessions

### DIFF
--- a/Sources/SpeziFirebaseAccount/FirebaseAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/FirebaseAccountService.swift
@@ -179,6 +179,7 @@ public final class FirebaseAccountService: AccountService { // swiftlint:disable
 
     @MainActor private var authStateDidChangeListenerHandle: AuthStateDidChangeListenerHandle?
     @MainActor private var lastNonce: String?
+    @MainActor private var currentSessionId: String?
 
     private var shouldQueue = false
     private var queuedUpdates: [UserUpdate] = []
@@ -658,6 +659,16 @@ extension FirebaseAccountService {
             return
         }
 
+        // sign out if a different session is now active
+        if let remoteSessionId = details.activeSessionId,
+           let localSessionId = self.currentSessionId,
+           remoteSessionId != localSessionId {
+            logger.info("Session invalidated, signing out.")
+            try? Auth.auth().signOut()
+            notifyUserRemoval()
+            return
+        }
+
         do {
             try await actionSemaphore.waitCheckingCancellation()
         } catch {
@@ -987,6 +998,11 @@ extension FirebaseAccountService {
 
     func notifyUserSignIn(user: User, isNewUser: Bool = false) async {
         let details = await buildUserQueryingStorageProvider(user: user, isNewUser: isNewUser)
+
+        // Capture the active session ID from the ID token's session claims
+        if let tokenResult = try? await user.getIDTokenResult() {
+            self.currentSessionId = tokenResult.claims["activeSessionId"] as? String
+        }
 
         logger.debug("Notifying SpeziAccount with updated user details.")
         account.supplyUserDetails(details)

--- a/Sources/SpeziFirebaseAccount/Keys/ActiveSessionIdKey.swift
+++ b/Sources/SpeziFirebaseAccount/Keys/ActiveSessionIdKey.swift
@@ -1,0 +1,19 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziAccount
+
+
+extension AccountDetails {
+    @AccountKey(name: "Active Session", as: String.self)
+    public var activeSessionId: String?
+}
+
+
+@KeyEntry(\.activeSessionId)
+extension AccountKeys {}


### PR DESCRIPTION
# Handle Active User Session

## :recycle: Current situation & Problem
For projects like MHC, we [want to enforce](https://github.com/StanfordBDHG/MyHeartCounts-Firebase/issues/50) that every user is strictly logged-in on only one device.


## :gear: Release Notes
For client-side logout upon session invalidation, the client needs to detect the change in the session ID and signs out if the session ID doesn't match its own.


## :books: Documentation
I made sure that this implementation is non-breaking: ActiveSessionIdKey is defined in the library, but apps must explicitly register `\.activeSessionId` in their AccountConfiguration for FirestoreAccountStorage to decode it from Firestore; if an app doesn't register the key, details.activeSessionId will be nil in handleUpdatedDetailsFromExternalStorage, and the nil-check in the code skips the sign-out logic.

Really happy for feedback here, @PSchmiedmayer & @lukaskollmer at al.!

## :white_check_mark: Testing
.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session tracking to improve account security. The app now automatically detects and handles session invalidation, signing out users when their session becomes invalid remotely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->