### PR TITLE
improve handling of invalid account credentials

### DIFF
--- a/Sources/SpeziFirebaseAccount/FirebaseAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/FirebaseAccountService.swift
@@ -240,17 +240,30 @@ public final class FirebaseAccountService: AccountService { // swiftlint:disable
             self?.handleStateDidChange(auth: auth, user: user)
         }
 
-        // if there is a cached user, we refresh the authentication token
-        Auth.auth().currentUser?.getIDTokenForcingRefresh(true) { _, error in
-            if let error {
-                guard (error as NSError).code != AuthErrorCode.networkError.rawValue else {
-                    return // we make sure that we don't remove the account when we don't have network (e.g., flight mode)
-                }
-
-                // guaranteed to be invoked on the main thread, see
-                // https://firebase.google.com/docs/reference/swift/firebaseauth/api/reference/Classes/User#getidtokenforcingrefresh_:completion:
-                MainActor.assumeIsolated {
-                    self.notifyUserRemoval()
+        Task { @MainActor in
+            guard let user = Auth.auth().currentUser else {
+                return
+            }
+            // if there is a cached user, we trigger a refresh to make sure everything is up to date and correct.
+            // if the refresh fails for a non-network-connectivity-related reason, we log the user out of the app.
+            // this also covers issues such as there being a (valid) logged-in user, but the app connecting to an incorrect firebase deployment.
+            do {
+                logger.notice("Triggering user reload")
+                try await user.reload()
+            } catch {
+                switch AuthErrorCode(rawValue: (error as NSError).code) {
+                case .networkError:
+                    // we make sure that we don't remove the account when we don't have network (e.g., flight mode)
+                    return
+                default:
+                    logger.error("Error trying to reload user: \(error). Will log out. (IsLoggedIn: \(Auth.auth().currentUser != nil))")
+                    do {
+                        try await self.logout()
+                    } catch FirebaseAccountError.notSignedIn {
+                        // the reload() call, for some errors, already triggers an automatic log out,
+                        // meaning that the user might already be signed out when we call `logout()` above.
+                        // we nonetheless call it unconditionally, since it will in both cases notify the Account module of the account removal.
+                    }
                 }
             }
         }

--- a/Sources/SpeziFirebaseAccount/FirebaseAccountService.swift
+++ b/Sources/SpeziFirebaseAccount/FirebaseAccountService.swift
@@ -263,6 +263,8 @@ public final class FirebaseAccountService: AccountService { // swiftlint:disable
                         // the reload() call, for some errors, already triggers an automatic log out,
                         // meaning that the user might already be signed out when we call `logout()` above.
                         // we nonetheless call it unconditionally, since it will in both cases notify the Account module of the account removal.
+                    } catch {
+                        logger.error("Error trying to log out after failed reload: \(error)")
                     }
                 }
             }

--- a/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
+++ b/Sources/SpeziFirebaseAccount/Views/FirebaseAccountModifier.swift
@@ -12,8 +12,6 @@ import SwiftUI
 
 
 struct FirebaseAccountModifier: ViewModifier {
-    static let logger = Logger(subsystem: "edu.stanford.spezi.firebase", category: "FirebaseAccount")
-
     @Environment(\.authorizationController)
     private var authorizationController
 
@@ -28,7 +26,6 @@ struct FirebaseAccountModifier: ViewModifier {
         content
             .task {
                 firebaseModel.authorizationController = authorizationController
-                Self.logger.debug("Retrieved the Sign in With Apple authorization controller from the SwiftUI environment!")
             }
     }
 }

--- a/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import XCTestExtensions
+import XCTSpeziAccount
 
 
 /// The `FirebaseAccountTests` require the Firebase Authentication Emulator to run at port 9099.
@@ -499,12 +500,8 @@ extension XCUIApplication {
         buttons["Account Setup"].tap()
         XCTAssertTrue(self.buttons["Login"].waitForExistence(timeout: 2.0))
         
-        try textFields["E-Mail Address"].enter(value: username)
-        try secureTextFields["Password"].enter(value: password)
-
-        scrollViews.buttons["Login"].tap()
-
-
+        try login(email: username, password: password)
+        
         if close {
             XCTAssertTrue(staticTexts[username].waitForExistence(timeout: 5.0))
             self.buttons["Close"].tap()
@@ -531,7 +528,7 @@ extension XCUIApplication {
 
         XCTAssertTrue(buttons["Signup"].exists)
         collectionViews.buttons["Signup"].tap()
-
+        dismissSavePasswordAlert(timeout: 7)
 
         XCTAssertTrue(staticTexts["Create a new Account"].waitForNonExistence(timeout: 10.0))
         XCTAssertTrue(staticTexts["Your Account"].waitForExistence(timeout: 10.0))

--- a/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
+++ b/Tests/UITests/TestAppUITests/FirebaseAccountTests.swift
@@ -391,6 +391,7 @@ final class FirebaseAccountTests: XCTestCase { // swiftlint:disable:this type_bo
 
         XCTAssertTrue(app.buttons["Close"].exists)
         app.buttons["Close"].tap()
+        app.dismissSavePasswordAlert(timeout: 7) // sometimes shows up even though there was no successful login
 
         XCTAssertTrue(app.buttons["Account Setup"].waitForExistence(timeout: 2.0))
 

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2FB07593299DF96E00C0B37F /* SpeziFirebaseAccount in Frameworks */ = {isa = PBXBuildFile; productRef = 2FB07592299DF96E00C0B37F /* SpeziFirebaseAccount */; };
 		2FB07595299DF96E00C0B37F /* SpeziFirebaseConfiguration in Frameworks */ = {isa = PBXBuildFile; productRef = 2FB07594299DF96E00C0B37F /* SpeziFirebaseConfiguration */; };
 		2FB07597299DF96E00C0B37F /* SpeziFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 2FB07596299DF96E00C0B37F /* SpeziFirestore */; };
+		806D151C2F9A86000036D411 /* XCTSpeziAccount in Frameworks */ = {isa = PBXBuildFile; productRef = 806D151B2F9A86000036D411 /* XCTSpeziAccount */; };
 		978DFE922ADB1E1600E2B9B5 /* SpeziFirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 978DFE912ADB1E1600E2B9B5 /* SpeziFirebaseStorage */; };
 		A9D83F9F2B0BDCC7000D0C78 /* SpeziFirebaseAccountStorage in Frameworks */ = {isa = PBXBuildFile; productRef = A9D83F9E2B0BDCC7000D0C78 /* SpeziFirebaseAccountStorage */; };
 /* End PBXBuildFile section */
@@ -85,6 +86,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				806D151C2F9A86000036D411 /* XCTSpeziAccount in Frameworks */,
 				2F746D9F29962B2A00BF54FE /* XCTestExtensions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -169,6 +171,7 @@
 			name = TestAppUITests;
 			packageProductDependencies = (
 				2F746D9E29962B2A00BF54FE /* XCTestExtensions */,
+				806D151B2F9A86000036D411 /* XCTSpeziAccount */,
 			);
 			productName = ExampleUITests;
 			productReference = 2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */;
@@ -203,6 +206,7 @@
 			mainGroup = 2F6D138928F5F384007C25D6;
 			packageReferences = (
 				2F746D9D29962B2A00BF54FE /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
+				806D151A2F9A86000036D411 /* XCRemoteSwiftPackageReference "SpeziAccount" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
@@ -656,6 +660,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		806D151A2F9A86000036D411 /* XCRemoteSwiftPackageReference "SpeziAccount" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziAccount.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.3.7;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -675,6 +687,11 @@
 		2FB07596299DF96E00C0B37F /* SpeziFirestore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SpeziFirestore;
+		};
+		806D151B2F9A86000036D411 /* XCTSpeziAccount */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 806D151A2F9A86000036D411 /* XCRemoteSwiftPackageReference "SpeziAccount" */;
+			productName = XCTSpeziAccount;
 		};
 		978DFE912ADB1E1600E2B9B5 /* SpeziFirebaseStorage */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
# improve handling of invalid account credentials

## :recycle: Current situation & Problem
the `FirebaseAccountService` currently calls `getIDTokenForcingRefresh(true)` as part of its module `configure()` function, if a cached Firebase User exists locally.
in the case of this call failing for a non-network-related reason, we call `notifyUserRemoval()`, which tells SpeziAccount that the logged-in user was removed.

issue: simply calling `notifyUserRemoval()` does not actually log out the user. if the `getIDTokenForcingRefresh(true)` call fails, Firebase will still have the (now known invalid) user logged in and cached locally. which leads to problems because Firebase now thinks that there is a logged-in user, while SpeziAccount (and SpeziFirebase) think that there is not.

we solve this, by:
- calling `logout()` instead of `notifyUserRemoval()`, to ensure that in this case the user gets correctly logged out. (`logout()` will notify SpeziAccount of the removal)
- calling `User.refresh()` instead of `User.getIDTokenForcingRefresh()`.
    - this seems to be the semantically more correct method to use here (we don't really care about the token itself, and in fact were silently ignoring it in the previous implementation)
    - this function will, in some cases / for some errors already trigger a user logout on its own (eg: when switching firebase deployments and the previously-logged-in user cannot be found in the new deployment), but we still have a dedicated `logout()` call to be sure


## :gear: Release Notes
- fixed: when the cached previously logged-in user detected on launch is invalid, a logout operation will be triggered. (previously, we would inform SpeziAccount of user removal, but not explicitly trigger a logout)


## :books: Documentation
n/a


## :white_check_mark: Testing
not easily testable (would need to spin up 2 separate emulators, to simulate the user logging in to the first one, and then terminating and relaunching the app and connecting to the second one)


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
