### PR TITLE
test: migrate unit tests from XCTest to Swift Testing

### DIFF
--- a/Tests/SpeziFirebaseTests/SpeziFirebaseTests.swift
+++ b/Tests/SpeziFirebaseTests/SpeziFirebaseTests.swift
@@ -6,11 +6,13 @@
 // SPDX-License-Identifier: MIT
 //
 
-import XCTest
+import Testing
 
 
-final class SpeziFirebaseTests: XCTestCase {
-    func testSpeziFirebase() throws {
-        XCTAssertTrue(true)
+@Suite("SpeziFirebase Tests")
+struct SpeziFirebaseTests {
+    @Test("Module loads successfully")
+    func moduleLoads() {
+        #expect(true)
     }
 }


### PR DESCRIPTION
## Summary

Migrates the unit test suite from XCTest to the modern [Swift Testing](https://developer.apple.com/xcode/swift-testing/) framework, as requested in #50.

## Changes

### `Tests/SpeziFirebaseTests/SpeziFirebaseTests.swift`

| Before (XCTest) | After (Swift Testing) |
|-----|-----|
| `import XCTest` | `import Testing` |
| `final class SpeziFirebaseTests: XCTestCase` | `@Suite("SpeziFirebase Tests") struct SpeziFirebaseTests` |
| `func testSpeziFirebase() throws` | `@Test("Module loads successfully") func moduleLoads()` |
| `XCTAssertTrue(true)` | `#expect(true)` |

### What's NOT migrated (and why)

UI tests (`Tests/UITests/`) remain XCTest-based since Swift Testing does not yet support `XCUIApplication` and UI testing workflows.

## References

- [Migrating a test from XCTest](https://developer.apple.com/documentation/testing/migratingfromxctest)
- [Meet Swift Testing (WWDC24)](https://developer.apple.com/videos/play/wwdc2024/10179)

Addresses #50